### PR TITLE
Ensure IAM plugins share the same auth token

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationBasePlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationBasePlugin.java
@@ -34,8 +34,8 @@ import com.mysql.cj.protocol.Protocol;
 import com.mysql.cj.protocol.a.NativePacketPayload;
 
 public abstract class AwsIamAuthenticationBasePlugin implements AuthenticationPlugin<NativePacketPayload> {
+  private String authenticationToken;
   protected Protocol<NativePacketPayload> protocol;
-  protected String authenticationToken;
   protected final String hostname;
   protected final int port;
   protected final String region;
@@ -57,6 +57,8 @@ public abstract class AwsIamAuthenticationBasePlugin implements AuthenticationPl
     return true;
   }
 
+  public abstract String getProtocolPluginName();
+
   public AwsIamAuthenticationBasePlugin(String hostname, int port, String region) {
     this.hostname = hostname;
     this.port = port;
@@ -68,6 +70,10 @@ public abstract class AwsIamAuthenticationBasePlugin implements AuthenticationPl
     if (this.authenticationToken == null) {
       this.authenticationToken = generateAuthenticationToken(user);
     }
+  }
+
+  protected String getAuthenticationToken() {
+    return this.authenticationToken;
   }
 
   private String generateAuthenticationToken(String user) {

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationClearPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationClearPlugin.java
@@ -46,8 +46,10 @@ public class AwsIamAuthenticationClearPlugin extends AwsIamAuthenticationBasePlu
   public boolean nextAuthenticationStep(NativePacketPayload fromServer, List<NativePacketPayload> toServer) {
     toServer.clear();
 
-    String encoding = this.protocol.versionMeetsMinimum(5, 7, 6) ? this.protocol.getPasswordCharacterEncoding() : "UTF-8";
-    String token = this.getAuthenticationToken();
+    final String encoding = this.protocol.versionMeetsMinimum(5, 7, 6)
+        ? this.protocol.getPasswordCharacterEncoding()
+        : "UTF-8";
+    final String token = this.getAuthenticationToken();
     NativePacketPayload bresp = new NativePacketPayload(StringUtils.getBytes(((token != null) ? token : ""), encoding));
 
     bresp.setPosition(bresp.getPayloadLength());

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationClearPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationClearPlugin.java
@@ -47,7 +47,8 @@ public class AwsIamAuthenticationClearPlugin extends AwsIamAuthenticationBasePlu
     toServer.clear();
 
     String encoding = this.protocol.versionMeetsMinimum(5, 7, 6) ? this.protocol.getPasswordCharacterEncoding() : "UTF-8";
-    NativePacketPayload bresp = new NativePacketPayload(StringUtils.getBytes(this.authenticationToken != null ? this.authenticationToken : "", encoding));
+    String token = this.getAuthenticationToken();
+    NativePacketPayload bresp = new NativePacketPayload(StringUtils.getBytes(((token != null) ? token : ""), encoding));
 
     bresp.setPosition(bresp.getPayloadLength());
     bresp.writeInteger(IntegerDataType.INT1, 0);

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
@@ -39,7 +39,7 @@ public class AwsIamAuthenticationPlugin extends AwsIamAuthenticationBasePlugin {
   }
 
   public String getProtocolPluginName() {
-    return "aws_iam_authentication";
+    return "mysql_native_password";
   }
 
   @Override
@@ -50,13 +50,16 @@ public class AwsIamAuthenticationPlugin extends AwsIamAuthenticationBasePlugin {
 
     NativePacketPayload bresp;
 
-    String pwd = this.getAuthenticationToken();
+    final String pwd = this.getAuthenticationToken();
 
-    if (fromServer == null || pwd == null || pwd.length() == 0) {
+    if ((fromServer == null) || (pwd == null) || (pwd.isEmpty())) {
       bresp = new NativePacketPayload(new byte[0]);
     } else {
       bresp = new NativePacketPayload(
-          Security.scramble411(pwd, fromServer.readBytes(StringSelfDataType.STRING_TERM), this.protocol.getPasswordCharacterEncoding()));
+          Security.scramble411(
+              pwd,
+              fromServer.readBytes(StringSelfDataType.STRING_TERM),
+              this.protocol.getPasswordCharacterEncoding()));
     }
     toServer.add(bresp);
 

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
@@ -50,7 +50,7 @@ public class AwsIamAuthenticationPlugin extends AwsIamAuthenticationBasePlugin {
 
     NativePacketPayload bresp;
 
-    String pwd = this.authenticationToken;
+    String pwd = this.getAuthenticationToken();
 
     if (fromServer == null || pwd == null || pwd.length() == 0) {
       bresp = new NativePacketPayload(new byte[0]);


### PR DESCRIPTION
### Summary

Ensure `AwsIamAuthenticationClearPlugin` and `AwsIamAuthenticationPlugin` share the same authentication token to avoid generating the authentication token multiple times.

### Additional Reviewers
@ColinKYuen 