### PR TITLE
AWS IAM Authentication (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,72 @@ The default XML parser contained a security risk which made the driver prone to 
 
 | Parameter       | Value           | Required      | Description  |
 | ------------- |:-------------:|:-------------:| ----- |
-|`allowXmlUnsafeExternalEntity` | Boolean | No | Set to true if you would like to use XML inputs that refer to external entities. WARNING: Setting this to true is unsafe since your system to be prone to XXE attacks.<br/><br/>**Default value:** `false` | 
+|`allowXmlUnsafeExternalEntity` | Boolean | No | Set to true if you would like to use XML inputs that refer to external entities. WARNING: Setting this to true is unsafe since your system to be prone to XXE attacks.<br/><br/>**Default value:** `false` |
+
+### AWS IAM Database Authentication
+
+An optional authentication method is to use Amazon AWS Identity and Access Management (IAM). 
+When using AWS IAM database authentication, host URL must be a valid Amazon endpoint, and not a custom domain or an IP address.
+<br>ie. `database-mysql-name.cluster-XYZ.us-east-2.rds.amazonaws.com`
+
+
+IAM database authentication is limited to certain database engines.
+For more information on limitations and recommendations, please [read](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html).
+
+#### Setup for IAM database Authentication for MySQL 
+1. Enable AWS IAM database authentication for existing database or create a new database on AWS RDS Console
+   1. [Creating new database](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html)
+   2. [Modifying existing database](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
+2. Create/Change and [use AWS IAM policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) for AWS IAM database authentication
+3. [Create a database account](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html) using AWS IAM database authentication
+   1. Connect to MySQL database using master logins and create a new user with the following<br>
+   `CREATE USER example_user_name IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';`
+
+| Parameter       | Value           | Required      | Description  |
+| ------------- |:-------------:|:-------------:| ----- |
+|`useAwsIam` | Boolean | No | Set to true if you would like to use AWS IAM database authentication<br/><br/>**Default value:** `false` |
+
+###### Sample Code
+```java
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import software.aws.rds.jdbc.mysql.shading.com.mysql.cj.conf.PropertyKey;
+import software.aws.rds.jdbc.mysql.Driver;
+
+public class AwsIamAuthenticationSample {
+
+   private static final String CONNECTION_STRING = "jdbc:mysql:aws://database-mysql-name.cluster-XYZ.us-east-2.rds.amazonaws.com";
+   private static final String USER = "example_user_name";
+
+   public static void main(String[] args) throws SQLException {
+      /// Load AWS RDS driver
+      DriverManager.registerDriver(new Driver());
+
+      // Create properties and set-up for AWS IAM database authentication
+      final Properties properties = new Properties();
+      properties.setProperty(PropertyKey.useAwsIam.getKeyName(), Boolean.TRUE.toString());
+      properties.setProperty(PropertyKey.USER.getKeyName(), USER);
+
+      // Try and make a connection
+      try (final Connection conn = DriverManager.getConnection(CONNECTION_STRING, properties)) {
+         try (final Statement myQuery = conn.createStatement()) {
+            try (final ResultSet rs = myQuery.executeQuery("SELECT NOW();")) {
+               while (rs.next()) {
+                  System.out.println(rs.getString(1));
+               }
+            }
+         }
+      } catch (final SQLException throwable) {
+         throw throwable;
+      }
+   }
+}
+```
 
 ## Development
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,15 +211,17 @@ tasks.withType<Checkstyle>().configureEach {
 
 dependencies {
     testImplementation("org.apache.commons:commons-dbcp2:2.8.0")
-    testImplementation("com.amazonaws:aws-java-sdk-rds:1.11.875")
+    testImplementation("com.amazonaws:aws-java-sdk-rds:1.12.70")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
     testImplementation("org.junit.platform:junit-platform-commons:1.6.2")
     testImplementation("org.junit.platform:junit-platform-engine:1.6.2")
     testImplementation("org.junit.platform:junit-platform-launcher:1.6.2")
     testImplementation("org.mockito:mockito-inline:3.6.28")
     testImplementation("org.hamcrest:hamcrest:2.2")
 
+    implementation("com.amazonaws:aws-java-sdk-rds:1.11.875")
     implementation("com.google.protobuf:protobuf-java:3.11.4")
     implementation("com.mchange:c3p0:0.9.5.5")
     implementation("org.jboss.jbossas:jboss-as-connector:6.1.0.Final")

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -665,6 +665,9 @@ public class PropertyDefinitions {
                 new BooleanPropertyDefinition(PropertyKey.allowXmlUnsafeExternalEntity, DEFAULT_VALUE_FALSE, RUNTIME_NOT_MODIFIABLE,
                         Messages.getString("ConnectionProperties.allowXmlUnsafeExternalEntity"), "0.2.0", CATEGORY_SECURITY, Integer.MAX_VALUE),
 
+                new BooleanPropertyDefinition(PropertyKey.useAwsIam, DEFAULT_VALUE_FALSE, RUNTIME_NOT_MODIFIABLE,
+                        Messages.getString("ConnectionProperties.useAwsIam"), "0.2.2", CATEGORY_SECURITY, Integer.MAX_VALUE),
+
                 //
                 // CATEGORY_PERFORMANCE
                 //

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -280,7 +280,8 @@ public enum PropertyKey {
     failoverWriterReconnectIntervalMs("failoverWriterReconnectIntervalMs", true), //
     failoverReaderConnectTimeoutMs("failoverReaderConnectTimeoutMs", true), //
     acceptAwsProtocolOnly("acceptAwsProtocolOnly", true),
-    allowXmlUnsafeExternalEntity("allowXmlUnsafeExternalEntity", true);
+    allowXmlUnsafeExternalEntity("allowXmlUnsafeExternalEntity", true),
+    useAwsIam("useAwsIam", true);
 
     private String keyName;
     private String ccAlias = null;

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
@@ -29,13 +29,6 @@
 
 package com.mysql.cj.protocol.a;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import com.mysql.cj.Constants;
 import com.mysql.cj.Messages;
 import com.mysql.cj.conf.PropertyDefinitions.SslMode;
@@ -53,6 +46,9 @@ import com.mysql.cj.protocol.a.NativeConstants.IntegerDataType;
 import com.mysql.cj.protocol.a.NativeConstants.StringLengthDataType;
 import com.mysql.cj.protocol.a.NativeConstants.StringSelfDataType;
 import com.mysql.cj.protocol.a.authentication.AuthenticationLdapSaslClientPlugin;
+import com.mysql.cj.protocol.a.authentication.AwsIamAuthenticationPlugin;
+import com.mysql.cj.protocol.a.authentication.AwsIamAuthenticationTokenHelper;
+import com.mysql.cj.protocol.a.authentication.AwsIamClearAuthenticationPlugin;
 import com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin;
 import com.mysql.cj.protocol.a.authentication.MysqlClearPasswordPlugin;
 import com.mysql.cj.protocol.a.authentication.MysqlNativePasswordPlugin;
@@ -60,6 +56,13 @@ import com.mysql.cj.protocol.a.authentication.MysqlOldPasswordPlugin;
 import com.mysql.cj.protocol.a.authentication.Sha256PasswordPlugin;
 import com.mysql.cj.protocol.a.result.OkPacket;
 import com.mysql.cj.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 public class NativeAuthenticationProvider implements AuthenticationProvider<NativePacketPayload> {
 
@@ -238,12 +241,46 @@ public class NativeAuthenticationProvider implements AuthenticationProvider<Nati
         List<AuthenticationPlugin<NativePacketPayload>> pluginsToInit = new LinkedList<>();
 
         // embedded plugins
-        pluginsToInit.add(new MysqlNativePasswordPlugin());
-        pluginsToInit.add(new MysqlClearPasswordPlugin());
         pluginsToInit.add(new Sha256PasswordPlugin());
         pluginsToInit.add(new CachingSha2PasswordPlugin());
         pluginsToInit.add(new MysqlOldPasswordPlugin());
         pluginsToInit.add(new AuthenticationLdapSaslClientPlugin());
+
+        final boolean useAwsIam = this.propertySet.getBooleanProperty(PropertyKey.useAwsIam).getValue();
+
+        if (useAwsIam) {
+            try {
+                Class.forName("com.amazonaws.auth.AWSCredentialsProvider");
+            } catch (ClassNotFoundException ex) {
+                throw ExceptionFactory.createException(Messages.getString(
+                    "AuthenticationAwsIamPlugin.MissingSDK"
+                ));
+            }
+
+            final String host = this.protocol.getSocketConnection().getHost();
+            final int port = this.protocol.getSocketConnection().getPort();
+
+            final AwsIamAuthenticationTokenHelper tokenHelper = new AwsIamAuthenticationTokenHelper(
+                host,
+                port,
+                this.propertySet.getStringProperty(PropertyKey.logger).getStringValue()
+            );
+
+            pluginsToInit.add(new AwsIamAuthenticationPlugin(tokenHelper));
+            pluginsToInit.add(new AwsIamClearAuthenticationPlugin(tokenHelper));
+
+            final String defaultPluginClassName = this.propertySet
+                    .getStringProperty(PropertyKey.defaultAuthenticationPlugin)
+                    .getPropertyDefinition()
+                    .getDefaultValue();
+
+            if (this.clientDefaultAuthenticationPlugin.equals(defaultPluginClassName)) {
+                this.clientDefaultAuthenticationPlugin = AwsIamAuthenticationPlugin.class.getName();
+            }
+        } else {
+            pluginsToInit.add(new MysqlNativePasswordPlugin());
+            pluginsToInit.add(new MysqlClearPasswordPlugin());
+        }
 
         // plugins from authenticationPluginClasses connection parameter
         String authenticationPluginClasses = this.propertySet.getStringProperty(PropertyKey.authenticationPlugins).getValue();

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationPlugin.java
@@ -1,0 +1,41 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.mysql.cj.protocol.a.authentication;
+
+public class AwsIamAuthenticationPlugin extends MysqlNativePasswordPlugin {
+
+  private final AwsIamAuthenticationTokenHelper helper;
+
+  public AwsIamAuthenticationPlugin(final AwsIamAuthenticationTokenHelper helper) {
+    this.helper = helper;
+  }
+
+  @Override
+  public void setAuthenticationParameters(String user, String password) {
+    super.setAuthenticationParameters(user, this.helper.getOrGenerateToken(user));
+  }
+}

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationTokenHelper.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamAuthenticationTokenHelper.java
@@ -1,0 +1,118 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.mysql.cj.protocol.a.authentication;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.rds.auth.GetIamAuthTokenRequest;
+import com.amazonaws.services.rds.auth.RdsIamAuthTokenGenerator;
+import com.mysql.cj.Messages;
+import com.mysql.cj.exceptions.ExceptionFactory;
+import com.mysql.cj.log.Log;
+import com.mysql.cj.log.LogFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AwsIamAuthenticationTokenHelper {
+
+  private String token;
+  private final String region;
+  private final String hostname;
+  private final int port;
+  private final Log log;
+  private static final int REGION_MATCHER_GROUP = 3;
+
+  public AwsIamAuthenticationTokenHelper(final String hostname, final int port, final String logger) {
+    this.log = LogFactory.getLogger(logger, Log.LOGGER_INSTANCE_NAME);
+    this.hostname = hostname;
+    this.port = port;
+    this.region = getRdsRegion();
+  }
+
+  public String getOrGenerateToken(final String user) {
+    if (this.token == null) {
+      this.token = generateAuthenticationToken(user);
+    }
+
+    return token;
+  }
+
+  private String generateAuthenticationToken(final String user) {
+    final RdsIamAuthTokenGenerator generator = RdsIamAuthTokenGenerator
+        .builder()
+        .region(this.region)
+        .credentials(new DefaultAWSCredentialsProviderChain())
+        .build();
+
+    return generator.getAuthToken(GetIamAuthTokenRequest
+        .builder()
+        .hostname(this.hostname)
+        .port(this.port)
+        .userName(user)
+        .build());
+  }
+
+  private String getRdsRegion() {
+    // Check Hostname
+    final Pattern auroraDnsPattern =
+        Pattern.compile(
+            "(.+)\\.(proxy-|cluster-|cluster-ro-|cluster-custom-)?[a-zA-Z0-9]+\\.([a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com",
+            Pattern.CASE_INSENSITIVE);
+    final Matcher matcher = auroraDnsPattern.matcher(hostname);
+    if (!matcher.find()) {
+      // Does not match Amazon's Hostname, throw exception
+      final String exceptionMessage = Messages.getString(
+          "AuthenticationAwsIamPlugin.UnsupportedHostname",
+          new String[]{hostname});
+
+      log.logTrace(exceptionMessage);
+      throw ExceptionFactory.createException(exceptionMessage);
+    }
+
+    // Get and Check Region
+    final String rdsRegion = matcher.group(REGION_MATCHER_GROUP);
+    try {
+      Regions.fromName(rdsRegion);
+    } catch (final IllegalArgumentException exception) {
+      final String exceptionMessage = Messages.getString(
+          "AuthenticationAwsIamPlugin.UnsupportedRegion",
+          new String[]{hostname});
+
+      log.logTrace(
+          exceptionMessage,
+          exception
+      );
+
+      throw ExceptionFactory.createException(
+          exceptionMessage,
+          exception
+      );
+    }
+    return rdsRegion;
+  }
+}

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamClearAuthenticationPlugin.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/authentication/AwsIamClearAuthenticationPlugin.java
@@ -1,0 +1,41 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package com.mysql.cj.protocol.a.authentication;
+
+public class AwsIamClearAuthenticationPlugin extends MysqlClearPasswordPlugin {
+
+  private final AwsIamAuthenticationTokenHelper helper;
+
+  public AwsIamClearAuthenticationPlugin(final AwsIamAuthenticationTokenHelper helper) {
+    this.helper = helper;
+  }
+
+  @Override
+  public void setAuthenticationParameters(String user, String password) {
+    super.setAuthenticationParameters(user, this.helper.getOrGenerateToken(user));
+  }
+}

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -47,6 +47,10 @@ AuthenticationProvider.BadDisabledAuthenticationPlugin=Can''t disable the defaul
 AuthenticationProvider.AuthenticationPluginRequiresSSL=SSL connection required for plugin ''{0}''. Check if "useSSL" is set to "true".
 AuthenticationProvider.UnexpectedAuthenticationApproval=Unexpected authentication approval: ''{0}'' plugin did not reported "done" state but server has approved connection.
 
+AuthenticationAwsIamPlugin.UnsupportedHostname=Unsupported AWS hostname ''{0}''. Amazon domain name in format *.AWS-Region.rds.amazonaws.com is expected
+AuthenticationAwsIamPlugin.UnsupportedRegion=Unsupported AWS region ''{0}''. For supported regions, please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
+AuthenticationAwsIamPlugin.MissingSDK=Unable to connect using AWS IAM authentication due to missing AWS Java SDK For Amazon RDS. Add dependency to classpath.
+
 Blob.0=indexToWriteAt must be >= 1
 Blob.1=IO Error while writing bytes to blob
 Blob.2="pos" argument can not be < 1.
@@ -997,6 +1001,7 @@ ConnectionProperties.failoverWriterReconnectIntervalMs=Interval of time to wait 
 ConnectionProperties.failoverReaderConnectTimeoutMs=Reader connection attempt timeout during a reader failover process. 
 ConnectionProperties.acceptAwsProtocolOnly=Set to true to only accept connections for URLs with the jdbc:mysql:aws:// protocol. This setting should be set to true when running an application that uses this driver simultaneously with another mysql driver that supports the same protocols (eg the mysql-connector-j driver), to ensure the driver protocols do not clash.
 ConnectionProperties.allowXmlUnsafeExternalEntity=Set to true to allow references to external entities when using XML inputs. 
+ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authentication.
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -561,6 +561,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
 
     this.hosts = cachedHosts;
+
     if (this.gatherPerfMetricsSetting) {
       this.metrics.registerUseCachedTopology(true);
     }

--- a/src/test/java/testsuite/integration/AwsIamAuthenticationIntegrationTest.java
+++ b/src/test/java/testsuite/integration/AwsIamAuthenticationIntegrationTest.java
@@ -1,0 +1,166 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package testsuite.integration;
+
+import com.mysql.cj.conf.PropertyKey;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+@Disabled
+public class AwsIamAuthenticationIntegrationTest {
+
+    private static final String DB_CONN_STR_PREFIX = "jdbc:mysql:aws://";
+    private static final String DB_READONLY_CONN_STR_SUFFIX =
+        System.getenv("DB_READONLY_CONN_STR_SUFFIX");
+    private static final String TEST_DB_CLUSTER_IDENTIFIER =
+        System.getenv("TEST_DB_CLUSTER_IDENTIFIER");
+    private static final String TEST_PASSWORD = System.getenv("TEST_PASSWORD");
+    private static final String TEST_DB_USER = System.getenv("TEST_DB_USER");
+    private static final String DB_CONN_STR = DB_CONN_STR_PREFIX + TEST_DB_CLUSTER_IDENTIFIER + DB_READONLY_CONN_STR_SUFFIX;
+
+    /**
+     * Attempt to connect using the wrong database username.
+     */
+    @Test
+    public void test_1_WrongDatabaseUsername() {
+        final Properties props = initProp("WRONG_" + TEST_DB_USER + "_USER", TEST_PASSWORD);
+
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN_STR, props)
+        );
+    }
+
+    /**
+     * Attempt to connect without specifying a database username.
+     */
+    @Test
+    public void test_2_NoDatabaseUsername() {
+        final Properties props = initProp("", TEST_PASSWORD);
+
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN_STR, props)
+        );
+    }
+
+    /**
+     * Attempt to connect using IP address instead of a hostname.
+     */
+    @Test
+    public void test_3_UsingIPAddress() {
+        final Properties props = initProp(TEST_DB_USER, TEST_PASSWORD);
+
+        final String hostname = DB_CONN_STR.substring(DB_CONN_STR_PREFIX.length());
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN_STR_PREFIX + hostToIP(hostname), props)
+        );
+    }
+
+    /**
+     * Attempt to connect using valid database username/password & valid Amazon RDS hostname.
+     */
+    @Test
+    public void test_4_ValidConnectionProperties() throws SQLException {
+        final Properties props = initProp(TEST_DB_USER, TEST_PASSWORD);
+
+        final Connection conn = DriverManager.getConnection(DB_CONN_STR, props);
+        Assertions.assertNotNull(conn);
+    }
+
+    /**
+     * Attempt to connect using valid database username, valid Amazon RDS hostname, but no password.
+     */
+    @Test
+    public void test_5_ValidConnectionPropertiesNoPassword() throws SQLException {
+        final Properties props = initProp(TEST_DB_USER, "");
+
+        final Connection conn = DriverManager.getConnection(DB_CONN_STR, props);
+        Assertions.assertNotNull(conn);
+    }
+
+    /**
+     * Attempts a valid connection followed by invalid connection
+     * without the AWS protocol in Connection URL.
+     */
+    @Test
+    void test_6_NoAwsProtocolConnection() throws SQLException {
+        final String DB_CONN = "jdbc:mysql://" + TEST_DB_CLUSTER_IDENTIFIER + DB_READONLY_CONN_STR_SUFFIX;
+        final Properties validProp = initProp(TEST_DB_USER, TEST_PASSWORD);
+        final Properties invalidProp = initProp("WRONG_" + TEST_DB_USER + "_USER", TEST_PASSWORD);
+
+        final Connection conn = DriverManager.getConnection(DB_CONN, validProp);
+        Assertions.assertNotNull(conn);
+
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN, invalidProp)
+        );
+    }
+
+    /**
+     * Attempts a valid connection followed by an invalid connection
+     * with Username in Connection URL.
+     */
+    @Test
+    void test_7_UserInConnStr() throws SQLException {
+        final Properties awsIamProp = new Properties();
+        awsIamProp.setProperty(PropertyKey.useAwsIam.getKeyName(), Boolean.TRUE.toString());
+
+        final Connection validConn = DriverManager.getConnection(DB_CONN_STR + "?user=" + TEST_DB_USER, awsIamProp);
+        Assertions.assertNotNull(validConn);
+
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN_STR + "?user=WRONG_" + TEST_DB_USER + "_USER", awsIamProp)
+        );
+    }
+
+    // Helper Functions
+    private Properties initProp(final String user, final String password) {
+        final Properties properties = new Properties();
+        properties.setProperty(PropertyKey.useAwsIam.getKeyName(), Boolean.TRUE.toString());
+        properties.setProperty(PropertyKey.USER.getKeyName(), user);
+        properties.setProperty(PropertyKey.PASSWORD.getKeyName(), password);
+
+        return properties;
+    }
+
+    private String hostToIP(final String hostname) throws UnknownHostException {
+        InetAddress inet = InetAddress.getByName(hostname);
+        return inet.getHostAddress();
+    }
+}

--- a/src/test/java/testsuite/simple/AwsIamAuthenticationHelperTest.java
+++ b/src/test/java/testsuite/simple/AwsIamAuthenticationHelperTest.java
@@ -1,0 +1,156 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package testsuite.simple;
+
+import com.mysql.cj.exceptions.CJException;
+import com.mysql.cj.log.StandardLogger;
+import com.mysql.cj.protocol.a.authentication.AwsIamAuthenticationTokenHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AwsIamAuthenticationHelperTest {
+
+    private static final int PORT = 3306;
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with valid host name and region.
+     */
+    @Test
+    public void test_1_ValidHostAndRegion() {
+        Assertions.assertNotNull(new AwsIamAuthenticationTokenHelper(
+            "MyDBInstanceName.SomeServerName.us-east-1.rds.amazonaws.com",
+            PORT,
+            StandardLogger.class.getName()
+        ));
+    }
+
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with invalid RDS format.
+     */
+    @Test
+    public void test_2_NotRdsHost() {
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "MyDBInstanceName.SomeServerName.us-east-2.notRDS.amazonaws.com",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+    }
+
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with invalid hostname.
+     */
+    @Test
+    public void test_3_NotAmazonHost() {
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "MyDBInstanceName.SomeServerName.us-east-2.rds.notamazon.com",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+    }
+
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with empty hostname.
+     */
+    @Test
+    public void test_4_EmptyHost() {
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                " ",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+    }
+
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with invalid RDS format.
+     */
+    @Test
+    public void test_5_InvalidHostUsingIP() {
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "192.168.0.1",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "localhost",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+    }
+
+    /**
+     *  Attempt to create new {@link AwsIamAuthenticationTokenHelper} with invalid region.
+     */
+    @Test
+    public void test_6_InvalidRegion() {
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "MyDBInstanceName.SomeServerName.fake-1.rds.amazonaws.com",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+
+        Assertions.assertThrows(
+            CJException.class,
+            () -> new AwsIamAuthenticationTokenHelper(
+                "MyDBInstanceName.SomeServerName. .rds.amazonaws.com",
+                PORT,
+                StandardLogger.class.getName()
+            )
+        );
+    }
+}


### PR DESCRIPTION
* Bump aws-java-sdk-rds from 1.11.875 to 1.12.70

Bumps [aws-java-sdk-rds](https://github.com/aws/aws-sdk-java) from 1.11.875 to 1.12.70.
- [Release notes](https://github.com/aws/aws-sdk-java/releases)
- [Changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-java/compare/1.11.875...1.12.70)

---
updated-dependencies:
- dependency-name: com.amazonaws:aws-java-sdk-rds
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

* feat: AWS IAM Authentication

Plugins were created to support AWS IAM Authentication when connecting to a RDS server.

### Summary

<!--- General summary / title -->

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->