### PR TITLE
fix: Unwrap ExecutionException in NodeMonitoringFailoverPlugin

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
@@ -183,7 +183,11 @@ public class NodeMonitoringFailoverPlugin implements IFailoverPlugin {
 
       result = executeFuncFuture.get();
     } catch (Exception ex) {
-      throw ex;
+      final Throwable throwable = ex.getCause();
+      if (throwable instanceof Error) {
+        throw (Error) throwable;
+      }
+      throw (Exception) throwable;
     } finally {
       // TODO: double check this
       this.monitorService.stopMonitoring(this.monitorContext);


### PR DESCRIPTION
### Summary

Unwrap `ExecutionException` in `NodeMonitoringFailoverPlugin`.

### Description

An alternative approach for #8 

### Additional Reviewers

@ColinKYuen 
@brunos-bq 
@sergiyv-bitquill 