### PR TITLE
fix: Catch ExecutionException specifically

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
@@ -34,6 +34,7 @@ import com.mysql.cj.log.Log;
 import org.jboss.util.NullArgumentException;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -182,8 +183,8 @@ public class NodeMonitoringFailoverPlugin implements IFailoverPlugin {
       }
 
       result = executeFuncFuture.get();
-    } catch (Exception ex) {
-      final Throwable throwable = ex.getCause();
+    } catch (ExecutionException exception) {
+      final Throwable throwable = exception.getCause();
       if (throwable instanceof Error) {
         throw (Error) throwable;
       }


### PR DESCRIPTION
### Summary

Catch ExecutionException specifically

### Description

Unwrap the exception if it is an `ExecutionException`, otherwise let it bubble up.

### Additional Reviewers

@sergiyv-bitquill 