### PR TITLE
Switch from CyclicBarrier to CountDownLatch

### DIFF
--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultiThreadedDefaultMonitorServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultiThreadedDefaultMonitorServiceTest.java
@@ -56,7 +56,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -229,7 +228,7 @@ class MultiThreadedDefaultMonitorServiceTest {
 
   /**
    * Run a {@link DefaultMonitorService} method concurrently in multiple threads.
-   * A {@link CyclicBarrier} is used to ensure all threads start at the same time.
+   * A {@link CountDownLatch} is used to ensure all threads start at the same time.
    *
    * @param numThreads   The number of threads to create.
    * @param services     The services to run in each thread.


### PR DESCRIPTION
### Summary

Use a CountDownLatch instead of a CyclicBarrier to ensure main thread waits for other threads to initialize.
https://www.baeldung.com/java-cyclicbarrier-countdownlatch

### Description

In some computers, the main thread might call `await()` before all test threads are set up and are ready to be executed. This causes all the threads to be stuck in a deadlock waiting for each other while the [thread generation loop](https://github.com/Bit-Quill/aws-mysql-jdbc/blob/8912a76288bced93b36d430a238820c02be86547/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultiThreadedDefaultMonitorServiceTest.java#L255) is unable to finish all iterations. 

### Additional Reviewers
@ColinKYuen 
@brunos-bq 
@matthewh-BQ 