### PR TITLE
refactor: Refactor IFailoverPlugin API.

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPlugin.java
@@ -1,20 +1,14 @@
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.conf.HostInfo;
-import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
-import java.sql.Connection;
 import java.util.concurrent.Callable;
 
 public class DefaultFailoverPlugin implements IFailoverPlugin {
 
   protected Log log;
 
-  public DefaultFailoverPlugin() {}
-
-  @Override
-  public void init(Connection connection, PropertySet propertySet, HostInfo hostInfo, IFailoverPlugin next, Log log) {
+  public DefaultFailoverPlugin(Log log) {
     if (log == null) {
       throw new NullArgumentException("log");
     }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPluginFactory.java
@@ -13,8 +13,6 @@ public class DefaultFailoverPluginFactory implements IFailoverPluginFactory {
       PropertySet propertySet,
       HostInfo hostInfo,
       IFailoverPlugin next, Log log) {
-    final IFailoverPlugin plugin = new DefaultFailoverPlugin();
-    plugin.init(connection, propertySet, hostInfo, next, log);
-    return plugin;
+    return new DefaultFailoverPlugin(log);
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IFailoverPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IFailoverPlugin.java
@@ -26,17 +26,11 @@
 
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.conf.HostInfo;
-import com.mysql.cj.conf.PropertySet;
-import com.mysql.cj.log.Log;
-
-import java.sql.Connection;
 import java.util.concurrent.Callable;
 
 //TODO: rename interface name to more generic one. The plugin has nothing to do with failover so the current
 // interface name is confusing and misleading. Rename interface implementations either.
 public interface IFailoverPlugin {
-  void init(Connection connection, PropertySet propertySet, HostInfo hostInfo, IFailoverPlugin next, Log log);
   Object execute(String methodName, Callable executeSqlFunc) throws Exception;
   void releaseResources();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPlugin.java
@@ -69,16 +69,13 @@ public class NodeMonitoringFailoverPlugin implements IFailoverPlugin {
     IMonitorService create(Log log);
   }
 
-  public NodeMonitoringFailoverPlugin() {
-  }
-
-  public void init(
+  public NodeMonitoringFailoverPlugin(
       Connection connection,
       PropertySet propertySet,
       HostInfo hostInfo,
       IFailoverPlugin next,
       Log log) {
-    this.init(
+    this(
         connection,
         propertySet,
         hostInfo,
@@ -87,7 +84,7 @@ public class NodeMonitoringFailoverPlugin implements IFailoverPlugin {
         DefaultMonitorService::new);
   }
 
-  void init(
+  public NodeMonitoringFailoverPlugin(
       Connection connection,
       PropertySet propertySet,
       HostInfo hostInfo,

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginFactory.java
@@ -14,9 +14,6 @@ public class NodeMonitoringFailoverPluginFactory implements IFailoverPluginFacto
       HostInfo hostInfo,
       IFailoverPlugin next,
       Log log) {
-
-    IFailoverPlugin plugin = new NodeMonitoringFailoverPlugin();
-    plugin.init(connection, propertySet, hostInfo, next, log);
-    return plugin;
+    return new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, next, log);
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginTest.java
@@ -107,7 +107,6 @@ class NodeMonitoringFailoverPluginTest {
   @BeforeEach
   void init() throws SQLException {
     closeable = MockitoAnnotations.openMocks(this);
-    plugin = new NodeMonitoringFailoverPlugin();
 
     initDefaultMockReturns();
   }
@@ -127,7 +126,7 @@ class NodeMonitoringFailoverPluginTest {
       final Log log) {
     Assertions.assertThrows(
         NullArgumentException.class,
-        () -> plugin.init(connection, set, info, failoverPlugin, log));
+        () -> new NodeMonitoringFailoverPlugin(connection, set, info, failoverPlugin, log));
   }
 
   @Test
@@ -247,8 +246,8 @@ class NodeMonitoringFailoverPluginTest {
     final Connection connection = Mockito.mock(Connection.class);
     final PropertySet set = new DefaultPropertySet();
     final HostInfo info = new HostInfo();
-    final IFailoverPlugin failoverPlugin = new DefaultFailoverPlugin();
     final Log log = new NullLogger("NodeMonitoringFailoverPluginTest");
+    final IFailoverPlugin failoverPlugin = new DefaultFailoverPlugin(log);
 
     return Stream.of(
         Arguments.of(null, set, info, failoverPlugin, log),
@@ -297,6 +296,6 @@ class NodeMonitoringFailoverPluginTest {
   }
 
   private void initializePlugin() {
-    plugin.init(connection, propertySet, hostInfo, mockPlugin, logger, monitorServiceInitializer);
+    plugin = new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, mockPlugin, logger, monitorServiceInitializer);
   }
 }


### PR DESCRIPTION
### Summary

Simplify the `IFailoverPlugin` API by removing the `init` method and let implementing classes handle the initialization.

### Description

The interface `IFailoverPlugin` currently has an `init` method that takes in a few parameters but not all parameters are required by all implementing classes. For instance, `DefaultFailoverPlugin` only needs `log`.

With the current design, if one implementing class requires extra initialization parameters the interface and all other implementing classes have to change.

Therefore it is better to pass the parameters via specific constructors.

### Additional Reviewers

@ColinKYuen 
@brunos-bq 
@matthewh-BQ 