### PR TITLE
Update plugins with most recent connection

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultFailoverPluginFactory.java
@@ -1,18 +1,16 @@
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
-
-import java.sql.Connection;
 
 public class DefaultFailoverPluginFactory implements IFailoverPluginFactory {
   @Override
   public IFailoverPlugin getInstance(
-      Connection connection,
+      ClusterAwareConnectionProxy proxy,
       PropertySet propertySet,
-      HostInfo hostInfo,
-      IFailoverPlugin next, Log log) {
+      IFailoverPlugin next,
+      Log log) {
     return new DefaultFailoverPlugin(log);
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -117,6 +117,18 @@ public class DefaultMonitorService implements IMonitorService {
   }
 
   @Override
+  public void stopMonitoringForAllConnections(Set<String> nodeKeys) {
+    final String node = this.threadContainer.getNode(nodeKeys);
+    if (node == null) {
+      this.log.logDebug("No existing monitor for the given set of node keys.");
+      return;
+    }
+    final IMonitor monitor = this.threadContainer.getMonitor(node);
+    monitor.clearContexts();
+    this.threadContainer.resetResource(monitor);
+  }
+
+  @Override
   public void releaseResources() {
     this.threadContainer = null;
     MonitorThreadContainer.releaseInstance();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/FailoverPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/FailoverPluginManager.java
@@ -29,6 +29,7 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
 import com.mysql.cj.util.StringUtils;
 import com.mysql.cj.util.Util;
@@ -50,6 +51,7 @@ public class FailoverPluginManager {
   protected PropertySet propertySet = null;
   protected HostInfo hostInfo;
   protected IFailoverPlugin headPlugin = null;
+  ClusterAwareConnectionProxy proxy;
 
   public FailoverPluginManager(Log logger) {
     if (logger == null) {
@@ -59,10 +61,9 @@ public class FailoverPluginManager {
     this.logger = logger;
   }
 
-  public void init(Connection connection, PropertySet propertySet, HostInfo hostInfo) {
-    this.connection = connection;
+  public void init(ClusterAwareConnectionProxy proxy, PropertySet propertySet) {
+    this.proxy = proxy;
     this.propertySet = propertySet;
-    this.hostInfo = hostInfo;
 
     String factoryClazzNames = propertySet
         .getStringProperty(PropertyKey.failoverPluginsFactories)
@@ -74,9 +75,8 @@ public class FailoverPluginManager {
 
     this.headPlugin = new DefaultFailoverPluginFactory()
         .getInstance(
-            this.connection,
+            this.proxy,
             this.propertySet,
-            this.hostInfo,
             null,
             this.logger);
 
@@ -93,9 +93,8 @@ public class FailoverPluginManager {
       for (int i = factories.length - 1; i >= 0; i--) {
         this.headPlugin = factories[i]
             .getInstance(
-                this.connection,
+                this.proxy,
                 this.propertySet,
-                this.hostInfo,
                 this.headPlugin,
                 this.logger);
       }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionProvider.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionProvider.java
@@ -26,9 +26,12 @@
 
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-public interface IMonitor extends Runnable {
-  void startMonitoring(MonitorConnectionContext context);
-  void stopMonitoring(MonitorConnectionContext context);
-  void clearContexts();
-  boolean isStopped();
+import com.mysql.cj.conf.HostInfo;
+
+import java.sql.Connection;
+
+public interface IConnectionProvider {
+  Connection getCurrentConnection();
+
+  HostInfo getCurrentHostInfo();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IFailoverPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IFailoverPluginFactory.java
@@ -1,11 +1,9 @@
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
 
-import java.sql.Connection;
-
 public interface IFailoverPluginFactory {
-  IFailoverPlugin getInstance(Connection connection, PropertySet propertySet, HostInfo hostInfo, IFailoverPlugin next, Log log);
+  IFailoverPlugin getInstance(ClusterAwareConnectionProxy proxy, PropertySet propertySet, IFailoverPlugin next, Log log);
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
@@ -40,7 +40,20 @@ public interface IMonitorService {
       int failureDetectionIntervalMillis,
       int failureDetectionCount);
 
+  /**
+   * Stop monitoring for a connection represented by the given
+   * {@link MonitorConnectionContext}. Removes the context from the {@link Monitor}.
+   * @param context The {@link MonitorConnectionContext} representing a connection.
+   */
   void stopMonitoring(MonitorConnectionContext context);
+
+  /**
+   * Stop monitoring the node for all connections represented by the given set of node keys.
+   * Usually used during the failover process.
+   *
+   * @param nodeKeys All known references to an Aurora node.
+   */
+  void stopMonitoringForAllConnections(Set<String> nodeKeys);
 
   void releaseResources();
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -112,7 +112,7 @@ public class Monitor implements IMonitor {
   @Override
   public void run() {
     try {
-      this.stopped.set(true);
+      this.stopped.set(false);
       while (true) {
         if (!this.contexts.isEmpty()) {
           final ConnectionStatus status = checkConnectionStatus(this.getConnectionCheckIntervalMillis());

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -115,7 +115,7 @@ public class Monitor implements IMonitor {
       this.stopped.set(true);
       while (true) {
         if (!this.contexts.isEmpty()) {
-          final ConnectionStatus status = checkConnectionStatus(this.connectionCheckIntervalMillis);
+          final ConnectionStatus status = checkConnectionStatus(this.getConnectionCheckIntervalMillis());
           final long currentTime = this.getCurrentTimeMillis();
           this.lastContextUsedTimestamp.set(currentTime);
 
@@ -126,8 +126,9 @@ public class Monitor implements IMonitor {
                 this.connectionCheckIntervalMillis);
           }
 
-          TimeUnit.MILLISECONDS.sleep(Math.max(0, this.connectionCheckIntervalMillis - status.elapsedTime));
+          TimeUnit.MILLISECONDS.sleep(Math.max(0, this.getConnectionCheckIntervalMillis() - status.elapsedTime));
         } else {
+          System.out.println("while empty");
           if ((this.getCurrentTimeMillis() - this.lastContextUsedTimestamp.get()) >= this.monitorDisposalTime) {
             monitorService.notifyUnused(this);
             break;
@@ -180,6 +181,10 @@ public class Monitor implements IMonitor {
   }
 
   int getConnectionCheckIntervalMillis() {
+    if (this.connectionCheckIntervalMillis == Integer.MAX_VALUE) {
+      // connectionCheckIntervalMillis is at Integer.MAX_VALUE because there are no contexts available.
+      return 0;
+    }
     return this.connectionCheckIntervalMillis;
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -128,7 +128,6 @@ public class Monitor implements IMonitor {
 
           TimeUnit.MILLISECONDS.sleep(Math.max(0, this.getConnectionCheckIntervalMillis() - status.elapsedTime));
         } else {
-          System.out.println("while empty");
           if ((this.getCurrentTimeMillis() - this.lastContextUsedTimestamp.get()) >= this.monitorDisposalTime) {
             monitorService.notifyUnused(this);
             break;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -26,7 +26,6 @@
 
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.Messages;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.conf.PropertySet;
@@ -41,6 +40,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class Monitor implements IMonitor {
@@ -66,6 +66,7 @@ public class Monitor implements IMonitor {
   private final AtomicLong lastContextUsedTimestamp = new AtomicLong();
   private final long monitorDisposalTime;
   private final IMonitorService monitorService;
+  private final AtomicBoolean stopped = new AtomicBoolean(true);
 
   public Monitor(
       ConnectionProvider connectionProvider,
@@ -103,9 +104,15 @@ public class Monitor implements IMonitor {
     this.connectionCheckIntervalMillis = findShortestIntervalMillis();
   }
 
+  public synchronized void clearContexts() {
+    this.contexts.clear();
+    this.connectionCheckIntervalMillis = findShortestIntervalMillis();
+  }
+
   @Override
   public void run() {
     try {
+      this.stopped.set(true);
       while (true) {
         if (!this.contexts.isEmpty()) {
           final ConnectionStatus status = checkConnectionStatus(this.connectionCheckIntervalMillis);
@@ -134,6 +141,7 @@ public class Monitor implements IMonitor {
       if (this.monitoringConn != null) {
         try {
           this.monitoringConn.close();
+          this.stopped.set(true);
         } catch (SQLException ex) {
           // ignore
         }
@@ -175,6 +183,11 @@ public class Monitor implements IMonitor {
     return this.connectionCheckIntervalMillis;
   }
 
+  @Override
+  public boolean isStopped() {
+    return this.stopped.get();
+  }
+
   private HostInfo copy(HostInfo src, Map<String, String> props) {
     return new HostInfo(
         null,
@@ -187,6 +200,10 @@ public class Monitor implements IMonitor {
   }
 
   private int findShortestIntervalMillis() {
+    if (this.contexts.isEmpty()) {
+      return Integer.MAX_VALUE;
+    }
+
     return this.contexts.stream()
         .min(Comparator.comparing(MonitorConnectionContext::getFailureDetectionIntervalMillis))
         .map(MonitorConnectionContext::getFailureDetectionIntervalMillis)

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginFactory.java
@@ -1,19 +1,16 @@
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
-import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
-
-import java.sql.Connection;
 
 public class NodeMonitoringFailoverPluginFactory implements IFailoverPluginFactory {
   @Override
   public IFailoverPlugin getInstance(
-      Connection connection,
+      ClusterAwareConnectionProxy proxy,
       PropertySet propertySet,
-      HostInfo hostInfo,
       IFailoverPlugin next,
       Log log) {
-    return new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, next, log);
+    return new NodeMonitoringFailoverPlugin(proxy, propertySet, next, log);
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultithreadedNodeMonitoringFailoverPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultithreadedNodeMonitoringFailoverPluginTest.java
@@ -180,8 +180,8 @@ public class MultithreadedNodeMonitoringFailoverPluginTest extends NodeMonitorin
     final List<NodeMonitoringFailoverPlugin> plugins = new ArrayList<>();
 
     for (int i = 0; i < numPlugins; i++) {
-      final NodeMonitoringFailoverPlugin nextPlugin = new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, mockPlugin, logger, initializer);
-      final NodeMonitoringFailoverPlugin plugin = new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, nextPlugin, logger, initializer);
+      final NodeMonitoringFailoverPlugin nextPlugin = new NodeMonitoringFailoverPlugin(proxy, propertySet, mockPlugin, logger, initializer);
+      final NodeMonitoringFailoverPlugin plugin = new NodeMonitoringFailoverPlugin(proxy, propertySet, nextPlugin, logger, initializer);
       plugins.add(plugin);
     }
 

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginBaseTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginBaseTest.java
@@ -36,6 +36,7 @@ import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.conf.RuntimeProperty;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -49,6 +50,7 @@ import java.util.concurrent.Callable;
  * Initialize constants and mock variables common to tests for {@link NodeMonitoringFailoverPlugin}.
  */
 public class NodeMonitoringFailoverPluginBaseTest {
+  @Mock ClusterAwareConnectionProxy proxy;
   @Mock Connection connection;
   @Mock Statement statement;
   @Mock ResultSet resultSet;
@@ -88,6 +90,8 @@ public class NodeMonitoringFailoverPluginBaseTest {
 
     when(mockPlugin.execute(anyString(), Mockito.any(Callable.class))).thenReturn("done");
 
+    when(proxy.getCurrentConnection()).thenReturn(connection);
+    when(proxy.getCurrentHostInfo()).thenReturn(hostInfo);
     when(connection.createStatement()).thenReturn(statement);
     when(statement.executeQuery(anyString())).thenReturn(resultSet);
     when(resultSet.next()).thenReturn(false);

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringFailoverPluginTest.java
@@ -26,18 +26,19 @@
 
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mysql.cj.conf.DefaultPropertySet;
-import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.exceptions.CJCommunicationsException;
+import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
 import com.mysql.cj.log.NullLogger;
 import org.jboss.invocation.InvocationException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,7 +47,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.sql.Connection;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
@@ -56,7 +56,6 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
       new InvocationException("exception", new Throwable()));
 
   private NodeMonitoringFailoverPlugin plugin;
-
   private AutoCloseable closeable;
 
   @BeforeEach
@@ -74,14 +73,13 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
   @ParameterizedTest
   @MethodSource("generateNullArguments")
   void test_1_initWithNullArguments(
-      final Connection connection,
+      final ClusterAwareConnectionProxy proxy,
       final PropertySet set,
-      final HostInfo info,
       final IFailoverPlugin failoverPlugin,
       final Log log) {
-    Assertions.assertThrows(
+    assertThrows(
         NullArgumentException.class,
-        () -> new NodeMonitoringFailoverPlugin(connection, set, info, failoverPlugin, log));
+        () -> new NodeMonitoringFailoverPlugin(proxy, set, failoverPlugin, log));
   }
 
   @Test
@@ -100,6 +98,7 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
         .thenReturn(Boolean.FALSE);
 
     initializePlugin();
+
     verify(initializer, Mockito.never()).create(Mockito.any());
   }
 
@@ -107,9 +106,10 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
   void test_4_executeWithFailoverDisabled() throws Exception {
     when(nativeFailureDetectionEnabledProperty.getValue())
         .thenReturn(Boolean.FALSE);
-    initializePlugin();
 
+    initializePlugin();
     plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
+
     verify(mockPlugin).execute(Mockito.eq(MONITOR_METHOD_NAME), Mockito.eq(sqlFunction));
   }
 
@@ -117,11 +117,11 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
   void test_5_executeWithNoNeedToMonitor() throws Exception {
     when(nativeFailureDetectionEnabledProperty.getValue())
         .thenReturn(Boolean.TRUE);
-    initializePlugin();
 
+    initializePlugin();
     plugin.execute(NO_MONITOR_METHOD_NAME, sqlFunction);
-    verify(mockPlugin)
-        .execute(Mockito.eq(NO_MONITOR_METHOD_NAME), Mockito.eq(sqlFunction));
+
+    verify(mockPlugin).execute(Mockito.eq(NO_MONITOR_METHOD_NAME), Mockito.eq(sqlFunction));
   }
 
   @Test
@@ -131,7 +131,7 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
 
     initializePlugin();
 
-    Assertions.assertThrows(Exception.class, () -> {
+    assertThrows(Exception.class, () -> {
       when(mockPlugin.execute(Mockito.any(), Mockito.any()))
           .thenThrow(EXECUTION_EXCEPTION);
 
@@ -148,7 +148,7 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
 
     initializePlugin();
 
-    Assertions.assertThrows(CJCommunicationsException.class, () -> {
+    assertThrows(CJCommunicationsException.class, () -> {
       when(context.isNodeUnhealthy())
           .thenReturn(Boolean.TRUE);
 
@@ -182,38 +182,35 @@ class NodeMonitoringFailoverPluginTest extends NodeMonitoringFailoverPluginBaseT
         });
 
     initializePlugin();
-
     final Object result = plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
-    Assertions.assertEquals(expected, result);
 
+    assertEquals(expected, result);
     verify(context, Mockito.atLeastOnce()).isNodeUnhealthy();
     verify(monitorService).stopMonitoring(Mockito.eq(context));
   }
 
   /**
    * Generate different sets of method arguments where one argument is null to ensure
-   * {@link NodeMonitoringFailoverPlugin#init(Connection, PropertySet, HostInfo, IFailoverPlugin, Log)}
+   * {@link NodeMonitoringFailoverPlugin#NodeMonitoringFailoverPlugin(ClusterAwareConnectionProxy, PropertySet, IFailoverPlugin, Log)}
    * can handle null arguments correctly.
    *
    * @return different sets of arguments.
    */
   private static Stream<Arguments> generateNullArguments() {
-    final Connection connection = Mockito.mock(Connection.class);
+    final ClusterAwareConnectionProxy proxy = Mockito.mock(ClusterAwareConnectionProxy.class);
     final PropertySet set = new DefaultPropertySet();
-    final HostInfo info = new HostInfo();
     final Log log = new NullLogger("NodeMonitoringFailoverPluginTest");
     final IFailoverPlugin failoverPlugin = new DefaultFailoverPlugin(log);
 
     return Stream.of(
-        Arguments.of(null, set, info, failoverPlugin, log),
-        Arguments.of(connection, null, info, failoverPlugin, log),
-        Arguments.of(connection, set, null, failoverPlugin, log),
-        Arguments.of(connection, set, info, null, log),
-        Arguments.of(connection, set, info, failoverPlugin, null)
+        Arguments.of(null, set, failoverPlugin, log),
+        Arguments.of(proxy, null, failoverPlugin, log),
+        Arguments.of(proxy, set, null, log),
+        Arguments.of(proxy, set, failoverPlugin, null)
     );
   }
 
   private void initializePlugin() {
-    plugin = new NodeMonitoringFailoverPlugin(connection, propertySet, hostInfo, mockPlugin, logger, initializer);
+    plugin = new NodeMonitoringFailoverPlugin(proxy, propertySet, mockPlugin, logger, initializer);
   }
 }


### PR DESCRIPTION
### Summary

feat: Pass ClusterAwareConnectionProxy to failover plugins so they can use are using the most up-to-date connection.

### Description

https://bitquill.atlassian.net/browse/RDS-475

After a failover has occurred, a new connection will be set in `ClusterAwareConnectionProxy`.
To let the `NodeMonitoringFailoverPlugin` know there is a new connection, we have to release the resources and reinitialize the plugin. This creates a lot of overhead when there are only 2 things the need to be updated:
1. connection
2. host info

This change removes the need to restart the monitoring plugin.

The `ClusterAwareConnectionProxy` implements `IConnectionProvider` which contains methods to retrieve the new connection. Plugins maintain a reference to the proxy, and whenever the connection or host info is required, call `getCurrentConnection()` or `getCurrentHostInfo()` to retrieve the most up to date info.

Currently on `Intospection`, if we don't restart the monitoring plugin so it uses the new connection, the monitor will keep checking the old instance while the proxy uses the new connection.
![image](https://user-images.githubusercontent.com/64801825/139355889-b8227a8d-5da2-4f10-b958-99136554cc7b.png)

After the changes the monitor will be updated automatically.
![image](https://user-images.githubusercontent.com/64801825/139356005-a5194387-3eb6-41ac-8361-c3f56667d13f.png)

### Additional Reviewers
@matthewh-BQ 
@ColinKYuen 
@brunos-bq 