### PR TITLE
test: Add multi-threaded tests for stop monitoring.

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
@@ -159,6 +159,7 @@ public class MonitorThreadContainer {
     }
 
     private synchronized void releaseResources() {
+        monitorMap.clear();
         tasksMap.values().stream()
             .filter(val -> !val.isDone() && !val.isCancelled())
             .forEach(val -> val.cancel(true));

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultiThreadedDefaultMonitorServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultiThreadedDefaultMonitorServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -43,23 +44,24 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
@@ -85,20 +87,28 @@ class MultiThreadedDefaultMonitorServiceTest {
   private final AtomicInteger counter = new AtomicInteger(0);
   private final AtomicInteger concurrentCounter = new AtomicInteger(0);
 
-  private static final AtomicBoolean isTest1Concurrent = new AtomicBoolean(false);
-  private static final AtomicBoolean isTest2Concurrent = new AtomicBoolean(false);
+  private static final Map<String, AtomicBoolean> CONCURRENT_TEST_MAP = new ConcurrentHashMap<>();
   private static final int FAILURE_DETECTION_TIME = 10;
   private static final int FAILURE_DETECTION_INTERVAL = 100;
   private static final int FAILURE_DETECTION_COUNT = 3;
   private static final int MONITOR_DISPOSE_TIME = 60000;
+  private static final String UNEXPECTED_EXCEPTION = "Test thread interrupted due to an unexpected exception.";
 
   private AutoCloseable closeable;
-  private ArgumentCaptor<MonitorConnectionContext> captor;
+  private ArgumentCaptor<MonitorConnectionContext> startMonitoringCaptor;
+  private ArgumentCaptor<MonitorConnectionContext> stopMonitoringCaptor;
+  private MonitorThreadContainer monitorThreadContainer;
 
   @BeforeEach
-  void init() {
+  void init(TestInfo testInfo) {
     closeable = MockitoAnnotations.openMocks(this);
-    captor = ArgumentCaptor.forClass(MonitorConnectionContext.class);
+    startMonitoringCaptor = ArgumentCaptor.forClass(MonitorConnectionContext.class);
+    stopMonitoringCaptor = ArgumentCaptor.forClass(MonitorConnectionContext.class);
+    monitorThreadContainer = MonitorThreadContainer.getInstance();
+
+    CONCURRENT_TEST_MAP.computeIfAbsent(
+        testInfo.getDisplayName(),
+        k -> new AtomicBoolean(false));
 
     when(monitorInitializer.createMonitor(
         any(HostInfo.class),
@@ -107,26 +117,37 @@ class MultiThreadedDefaultMonitorServiceTest {
         .thenReturn(monitor);
     when(executorServiceInitializer.createExecutorService()).thenReturn(service);
     doReturn(taskA).when(service).submit(any(Monitor.class));
-    doNothing().when(monitor).startMonitoring(captor.capture());
+    doNothing().when(monitor).startMonitoring(startMonitoringCaptor.capture());
+    doNothing().when(monitor).stopMonitoring(stopMonitoringCaptor.capture());
     when(propertySet.getIntegerProperty(any(String.class))).thenReturn(integerProperty);
     when(integerProperty.getValue()).thenReturn(MONITOR_DISPOSE_TIME);
   }
 
   @AfterEach
-  void cleanUp() throws Exception {
+  void cleanUp(TestInfo testInfo) throws Exception {
     counter.set(0);
+
+    if (concurrentCounter.get() > 0) {
+      CONCURRENT_TEST_MAP.get(testInfo.getDisplayName()).getAndSet(true);
+    }
+
     concurrentCounter.set(0);
     closeable.close();
+    MonitorThreadContainer.releaseInstance();
   }
 
+  /**
+   * Ensure each test case was executed concurrently at least once.
+   */
   @AfterAll
-  static void checkConcurrency() {
-    assertTrue(isTest1Concurrent.get());
-    assertTrue(isTest2Concurrent.get());
+  static void assertConcurrency() {
+    CONCURRENT_TEST_MAP.forEach((key, value) -> assertTrue(
+        value.get(),
+        String.format("Test '%s' was executed sequentially.", key)));
   }
 
-  @RepeatedTest(1000)
-  void test_1_multipleConnectionsToDifferentNodes()
+  @RepeatedTest(value = 1000, name = "start monitoring with multiple connections to different nodes")
+  void test_1_startMonitoring_multipleConnectionsToDifferentNodes()
       throws ExecutionException, InterruptedException {
     final int numConnections = 10;
     final List<Set<String>> nodeKeyList = generateNodeKeys(numConnections, true);
@@ -138,26 +159,20 @@ class MultiThreadedDefaultMonitorServiceTest {
           services,
           nodeKeyList);
 
-      final List<MonitorConnectionContext> capturedContexts = captor.getAllValues();
+      final List<MonitorConnectionContext> capturedContexts = startMonitoringCaptor.getAllValues();
 
       assertEquals(numConnections, services.get(0).threadContainer.getMonitorMap().size());
-      assertEquals(numConnections, capturedContexts.size());
-
       assertTrue((contexts.size() == capturedContexts.size())
           && contexts.containsAll(capturedContexts)
           && capturedContexts.containsAll(contexts));
       verify(monitorInitializer, times(numConnections)).createMonitor(eq(info), eq(propertySet), any(IMonitorService.class));
-
-      if (concurrentCounter.get() != 0) {
-        isTest1Concurrent.getAndSet(true);
-      }
     } finally {
       releaseResources(services);
     }
   }
 
-  @RepeatedTest(1000)
-  void test_2_multipleConnectionsToOneNode() throws InterruptedException, ExecutionException {
+  @RepeatedTest(value = 1000, name = "start monitoring with multiple connections to the same node")
+  void test_2_startMonitoring_multipleConnectionsToOneNode() throws InterruptedException, ExecutionException {
     final int numConnections = 10;
     final List<Set<String>> nodeKeyList = generateNodeKeys(numConnections, false);
     final List<DefaultMonitorService> services = generateServices(numConnections);
@@ -168,92 +183,76 @@ class MultiThreadedDefaultMonitorServiceTest {
           services,
           nodeKeyList);
 
-      final List<MonitorConnectionContext> capturedContexts = captor.getAllValues();
+      final List<MonitorConnectionContext> capturedContexts = startMonitoringCaptor.getAllValues();
 
       assertEquals(1, services.get(0).threadContainer.getMonitorMap().size());
-      assertEquals(numConnections, capturedContexts.size());
-
       assertTrue((contexts.size() == capturedContexts.size())
           && contexts.containsAll(capturedContexts)
           && capturedContexts.containsAll(contexts));
 
       verify(monitorInitializer).createMonitor(eq(info), eq(propertySet), any(IMonitorService.class));
+    } finally {
+      releaseResources(services);
+    }
+  }
 
-      if (concurrentCounter.get() != 0) {
-        isTest2Concurrent.getAndSet(true);
-      }
+  @RepeatedTest(value = 1000, name = "stop monitoring with multiple connections to different nodes")
+  void test_3_stopMonitoring_multipleConnectionsToDifferentNodes()
+      throws ExecutionException, InterruptedException {
+    final int numConnections = 10;
+    final List<MonitorConnectionContext> contexts = generateContexts(numConnections, true);
+    final List<DefaultMonitorService> services = generateServices(numConnections);
+
+    try {
+      runStopMonitor(numConnections, services, contexts);
+
+      final List<MonitorConnectionContext> capturedContexts = stopMonitoringCaptor.getAllValues();
+      assertTrue((contexts.size() == capturedContexts.size())
+          && contexts.containsAll(capturedContexts)
+          && capturedContexts.containsAll(contexts));
+    } finally {
+      releaseResources(services);
+    }
+  }
+
+  @RepeatedTest(value = 1000, name = "stop monitoring with multiple connections to the same node")
+  void test_4_stopMonitoring_multipleConnectionsToTheSameNode()
+      throws ExecutionException, InterruptedException {
+    final int numConnections = 10;
+    final List<MonitorConnectionContext> contexts = generateContexts(numConnections, false);
+    final List<DefaultMonitorService> services = generateServices(numConnections);
+
+    try {
+      runStopMonitor(numConnections, services, contexts);
+
+      final List<MonitorConnectionContext> capturedContexts = stopMonitoringCaptor.getAllValues();
+      assertTrue((contexts.size() == capturedContexts.size())
+          && contexts.containsAll(capturedContexts)
+          && capturedContexts.containsAll(contexts));
     } finally {
       releaseResources(services);
     }
   }
 
   /**
-   * Run {@link DefaultMonitorService#startMonitoring(Set, HostInfo, PropertySet, int, int, int)} multiple times.
-   *
-   * @param runs        The number of times to run the methods.
-   * @param services    The {@link DefaultMonitorService} used to run each method.
-   * @param nodeKeyList The sets of node keys for each service.
-   * @return The {@link MonitorConnectionContext} returned by
-   * {@link DefaultMonitorService#startMonitoring(Set, HostInfo, PropertySet, int, int, int)}.
-   * @throws InterruptedException if a thread has been interrupted.
-   * @throws ExecutionException   if an exception occurred within a thread.
-   */
-  private List<MonitorConnectionContext> runStartMonitor(
-      final int runs,
-      final List<DefaultMonitorService> services,
-      final List<Set<String>> nodeKeyList)
-      throws ExecutionException, InterruptedException {
-    final List<Object> results = runMethodAsync(
-        runs,
-        services,
-        nodeKeyList,
-        (service, nodes) -> {
-          final int val = counter.getAndIncrement();
-          if (val != 0) {
-            concurrentCounter.getAndIncrement();
-          }
-
-          final MonitorConnectionContext context = service
-              .startMonitoring(
-                  nodes,
-                  info,
-                  propertySet,
-                  FAILURE_DETECTION_TIME,
-                  FAILURE_DETECTION_INTERVAL,
-                  FAILURE_DETECTION_COUNT);
-
-          counter.getAndDecrement();
-          return context;
-        }
-    );
-
-    return results.stream()
-        .map(obj -> (MonitorConnectionContext) obj)
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Run a {@link DefaultMonitorService} method concurrently in multiple threads.
+   * Run {@link DefaultMonitorService#startMonitoring(Set, HostInfo, PropertySet, int, int, int)}
+   * concurrently in multiple threads.
    * A {@link CountDownLatch} is used to ensure all threads start at the same time.
    *
    * @param numThreads   The number of threads to create.
    * @param services     The services to run in each thread.
    * @param nodeKeysList The set of nodes assigned to each service.
-   * @param method       A method in {@link DefaultMonitorService} to run in multiple threads.
    * @return the results from executing the method.
    * @throws InterruptedException if a thread has been interrupted.
    * @throws ExecutionException   if an exception occurred within a thread.
    */
-  private List<Object> runMethodAsync(
+  private List<MonitorConnectionContext> runStartMonitor(
       final int numThreads,
       final List<DefaultMonitorService> services,
-      final List<Set<String>> nodeKeysList,
-      final BiFunction<DefaultMonitorService, Set<String>, Object> method
+      final List<Set<String>> nodeKeysList
   ) throws InterruptedException, ExecutionException {
-    final String exceptionMessage = "Test thread interrupted due to an unexpected exception.";
-
     final CountDownLatch latch = new CountDownLatch(1);
-    final List<CompletableFuture<Object>> threads = new ArrayList<>();
+    final List<CompletableFuture<MonitorConnectionContext>> threads = new ArrayList<>();
 
     for (int i = 0; i < numThreads; i++) {
       final DefaultMonitorService service = services.get(i);
@@ -264,23 +263,88 @@ class MultiThreadedDefaultMonitorServiceTest {
           // Wait until each thread is ready to start running.
           latch.await();
         } catch (final InterruptedException e) {
-          fail(exceptionMessage, e);
+          fail(UNEXPECTED_EXCEPTION, e);
         }
 
         // Execute the method.
-        return method.apply(service, nodeKeys);
+        final int val = counter.getAndIncrement();
+        if (val != 0) {
+          concurrentCounter.getAndIncrement();
+        }
+
+        final MonitorConnectionContext context = service
+            .startMonitoring(
+                nodeKeys,
+                info,
+                propertySet,
+                FAILURE_DETECTION_TIME,
+                FAILURE_DETECTION_INTERVAL,
+                FAILURE_DETECTION_COUNT);
+
+        counter.getAndDecrement();
+        return context;
       }));
     }
 
     // Start all threads.
     latch.countDown();
 
-    final List<Object> contexts = new ArrayList<>();
-    for (final CompletableFuture<Object> thread : threads) {
+    final List<MonitorConnectionContext> contexts = new ArrayList<>();
+    for (final CompletableFuture<MonitorConnectionContext> thread : threads) {
       contexts.add(thread.get());
     }
 
     return contexts;
+  }
+
+  /**
+   * Run {@link DefaultMonitorService#stopMonitoring(MonitorConnectionContext)}
+   * concurrently in multiple threads.
+   * A {@link CountDownLatch} is used to ensure all threads start at the same time.
+   *
+   * @param numThreads The number of threads to create.
+   * @param services   The services to run in each thread.
+   * @param contexts   The context for each connection wanting to stop monitoring.
+   * @throws InterruptedException if a thread has been interrupted.
+   * @throws ExecutionException   if an exception occurred within a thread.
+   */
+  private void runStopMonitor(
+      final int numThreads,
+      final List<DefaultMonitorService> services,
+      final List<MonitorConnectionContext> contexts)
+      throws ExecutionException, InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final List<CompletableFuture<Void>> threads = new ArrayList<>();
+
+    for (int i = 0; i < numThreads; i++) {
+      final DefaultMonitorService service = services.get(i);
+      final MonitorConnectionContext context = contexts.get(i);
+
+      threads.add(CompletableFuture.runAsync(() -> {
+        try {
+          // Wait until each thread is ready to start running.
+          latch.await();
+        } catch (final InterruptedException e) {
+          fail(UNEXPECTED_EXCEPTION, e);
+        }
+
+        // Execute the method.
+        final int val = counter.getAndIncrement();
+        if (val != 0) {
+          concurrentCounter.getAndIncrement();
+        }
+
+        service.stopMonitoring(context);
+        counter.getAndDecrement();
+      }));
+    }
+
+    // Start all threads.
+    latch.countDown();
+
+    for (final CompletableFuture<Void> thread : threads) {
+      thread.get();
+    }
   }
 
   /**
@@ -303,6 +367,31 @@ class MultiThreadedDefaultMonitorServiceTest {
     }
 
     return nodeKeysList;
+  }
+
+  /**
+   * Generate multiple contexts with either different node keys or the same node keys,
+   * and add the contexts to the monitor thread container.
+   *
+   * @param numContexts The amount of contexts to create.
+   * @param diffContext Whether the contexts have the same set of node keys or different sets of node keys.
+   * @return the generated contexts.
+   */
+  private List<MonitorConnectionContext> generateContexts(final int numContexts, final boolean diffContext) {
+    final List<Set<String>> nodeKeysList = generateNodeKeys(numContexts, diffContext);
+    final List<MonitorConnectionContext> contexts = new ArrayList<>();
+
+    nodeKeysList.forEach(nodeKeys -> {
+      monitorThreadContainer.getOrCreateMonitor(nodeKeys, () -> monitor);
+      contexts.add(new MonitorConnectionContext(
+          nodeKeys,
+          logger,
+          FAILURE_DETECTION_TIME,
+          FAILURE_DETECTION_INTERVAL,
+          FAILURE_DETECTION_COUNT));
+    });
+
+    return contexts;
   }
 
   /**


### PR DESCRIPTION
### Summary

test: Add multi-threaded tests for `DefaultMonitorService#stopMonitoring`

### Description

- simplify methods for running multi-threaded tests
- add 2 tests for stopMonitoring

https://bitquill.atlassian.net/browse/RDS-503

### Additional Reviewers
@matthewh-BQ 
@brunos-bq 
@ColinKYuen 