### PR TITLE
Debug hanging test

### DIFF
--- a/src/test/java/testsuite/regression/ConnectionRegressionTest.java
+++ b/src/test/java/testsuite/regression/ConnectionRegressionTest.java
@@ -81,6 +81,7 @@ import java.lang.reflect.*;
 import java.net.*;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.Charset;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.sql.*;
 import java.sql.Driver;
@@ -6818,6 +6819,13 @@ public class ConnectionRegressionTest extends BaseTestCase {
             // In some older Linux kernels the underlying system call may return 1 when actually no bytes are available in a CLOSE_WAIT state socket, even if EOF
             // has been reached.
             int available = this.underlyingInputStream.available();
+            try {
+                if (Arrays.asList(SSLContext.getDefault().createSSLEngine().getEnabledProtocols()).contains("TLSv1.3")) {
+                    return available;
+                }
+            } catch (NoSuchAlgorithmException e) {
+                fail("SSLContext used by the environment cannot be retrieved.");
+            }
             return available == 0 ? 1 : available;
         }
 


### PR DESCRIPTION
### Summary

#39 Finds the hanging test and fixes the failing test `testBug69579`.
This PR investigates why the test is hanging.

### Description

`testBug73053` hangs on Github Actions when it is attempting to close the test connection, but passes just fine locally. This is because the remote environment uses `TLSv1.3`.

When closing a connection, if `TLSv1.3` is used, the driver roughly follows this workflow: 
```
SSLSocketImpl#duplexCloseOutput -> SSLSocketImpl#bruteForceCloseInput(false) -> SSLSocketInputRecord#deplete
```
and it gets stuck in an infinite loop in `SSLSocketInputRecord#deplete`
```Java
while ((remaining = is.available()) != 0) {
    is.skip(remaining);
}
```
This method uses a custom `InputStream` implemented for `testBug73053`: `TestBug73053InputStreamWrapper`, where `is.available()` [will never return 0](https://github.com/awslabs/aws-mysql-jdbc/blob/ba9c5af7dbc68a83975f9cbba8376f65d515597a/src/test/java/testsuite/regression/ConnectionRegressionTest.java#L6799).
```Java
return available == 0 ? 1 : available;
```

The reasoning for this condition was due to this bug: https://bugs.mysql.com/bug.php?id=73053
> In some older Linux kernels the underlying system call may return 1 when actually no bytes are available in a CLOSE_WAIT state socket, even if EOF has been reached.

![image](https://user-images.githubusercontent.com/64801825/140823802-b79f2534-a448-4ca8-8674-2168ab3cbf7f.png)

### Additional Reviewers

@matthewh-BQ 
@brunos-bq 
@ColinKYuen 
@sergiyv-bitquill 