### PR TITLE
refactor: Removed condition of adjustedFailureCount

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
@@ -120,10 +120,8 @@ public class MonitorConnectionContext {
 
       final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
       final long maxInvalidNodeDurationMillis = (long) this.getFailureDetectionIntervalMillis() * this.getFailureDetectionCount();
-      final float adjustedFailureCount = (float) this.getFailureDetectionIntervalMillis() / validationIntervalTimeMillis * this.getFailureDetectionCount();
 
-      // TODO: condition with failure counts may be unnecessary
-      if (this.getFailureCount() >= adjustedFailureCount && invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
+      if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
         this.log.logTrace(
             String.format(
                 "[MonitorConnectionContext] node '%s' is *dead*.",


### PR DESCRIPTION
### Summary

Removed condition of adjustedFailureCount

### Description

MonitorConnectionContext does NOT need the extra check of adjustedFailureCount.

The condition for checking (failureCount >= adjustedFailureCount) is always going to be hit before or at the same time the other condition of (invalidNodeDuration >= maxInvalidNodeDuration).

In the current implementation, since both cases need to be true for the context to be considered unhealthy, it is not needed.

In the case of letting either condition being hit to consider a context as unhealthy, then given the following parameters
- validationInterval = 300
- failureDetectionTime = 10
- failureDetectionInterval = 100
- failureDetectionCount = 2
This would trigger off the condition of (failureCount >= adjustedFailureCount) as soon as it hits the first failureCount (= 1) as adjustedFailureCount = (failureDetectionInterval / validationInterval) * failureDetectionCount = 0.66…

### Additional Reviewers

@karenc-bq 
@sergiyv-bitquill 