### PR TITLE
Rds-516 method signature

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -1298,11 +1298,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.close();
           return null;
         });
-      }
-      catch(SQLException sqlEx) {
+      } catch(SQLException sqlEx) {
         throw sqlEx;
-      }
-      catch(Exception ex) {
+      } catch(Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();
@@ -1322,11 +1320,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.abort(executor);
           return null;
         });
-      }
-      catch(SQLException sqlEx) {
+      } catch(SQLException sqlEx) {
         throw sqlEx;
-      }
-      catch(Exception ex) {
+      } catch(Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();
@@ -1346,11 +1342,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.abortInternal();
           return null;
         });
-      }
-      catch(SQLException sqlEx) {
+      } catch(SQLException sqlEx) {
         throw sqlEx;
-      }
-      catch(Exception ex) {
+      } catch(Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -162,21 +162,20 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         return args[0].equals(this);
       }
 
-      // TODO: verify if synchronized is needed here
-      //synchronized (ClusterAwareConnectionProxy.this) {
-      Object result = null;
+      synchronized (ClusterAwareConnectionProxy.this.lockObject) {
+        Object result = null;
 
-      try {
-        result = ClusterAwareConnectionProxy.this.pluginManager.execute(method.getName(), () -> method.invoke(this.invokeOn, args));
-        result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
-      } catch (InvocationTargetException e) {
-        dealWithInvocationException(e);
-      } catch (IllegalStateException e) {
-        dealWithIllegalStateException(e);
+        try {
+          result = ClusterAwareConnectionProxy.this.pluginManager.execute(this.invokeOn.getClass(), method.getName(), () -> method.invoke(this.invokeOn, args));
+          result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
+        } catch (InvocationTargetException e) {
+          dealWithInvocationException(e);
+        } catch (IllegalStateException e) {
+          dealWithIllegalStateException(e);
+        }
+
+        return result;
       }
-
-      return result;
-      //}
     }
 
   }
@@ -211,7 +210,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    *
    * @return true if cluster-aware failover is enabled
    */
-  public synchronized boolean isFailoverEnabled() {
+  public boolean isFailoverEnabled() {
     return this.enableFailoverSetting
         && !this.isRdsProxy
         && this.isClusterTopologyAvailable
@@ -304,7 +303,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     initProxy(connectionUrl, connectionPluginManagerInitializer);
   }
 
-  protected synchronized void initSettings(ConnectionUrl connectionUrl) throws SQLException {
+  protected void initSettings(ConnectionUrl connectionUrl) throws SQLException {
     JdbcPropertySetImpl connProps = new JdbcPropertySetImpl();
     try {
       connProps.initializeProperties(connectionUrl.getMainHost().exposeAsProperties());
@@ -334,18 +333,18 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     this.failoverSocketTimeoutMs = connProps.getIntegerProperty(PropertyKey.socketTimeout).getValue();
   }
 
-  protected synchronized void initLogger(ConnectionUrl connUrl) {
+  protected void initLogger(ConnectionUrl connUrl) {
     String loggerClassName = connUrl.getOriginalProperties().get(PropertyKey.logger.getKeyName());
     if (!StringUtils.isNullOrEmpty(loggerClassName)) {
       this.log = LogFactory.getLogger(loggerClassName, Log.LOGGER_INSTANCE_NAME);
     }
   }
 
-  protected synchronized void initProxy(ConnectionUrl connUrl) throws SQLException {
+  protected void initProxy(ConnectionUrl connUrl) throws SQLException {
     this.initProxy(connUrl, ConnectionPluginManager::new);
   }
 
-  private synchronized void initProxy(
+  private void initProxy(
       ConnectionUrl connUrl,
       Function<Log, ConnectionPluginManager> connectionPluginManagerInitializer)
       throws SQLException {
@@ -411,7 +410,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     return pair;
   }
 
-  private synchronized void validateHostPatternSetting(String hostPattern) throws SQLException {
+  private void validateHostPatternSetting(String hostPattern) throws SQLException {
     if (!isDnsPatternValid(hostPattern)) {
       // "Invalid value for the 'clusterInstanceHostPattern' configuration setting - the host pattern must contain a '?'
       // character as a placeholder for the DB instance identifiers of the instances in the cluster"
@@ -491,7 +490,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  private synchronized HostInfo createClusterInstanceTemplate(HostInfo mainHost, String host, int port) {
+  private HostInfo createClusterInstanceTemplate(HostInfo mainHost, String host, int port) {
     Map<String, String> properties = new HashMap<>(this.initialConnectionProps);
     properties.put(PropertyKey.connectTimeout.getKeyName(), String.valueOf(this.failoverConnectTimeoutMs));
     properties.put(PropertyKey.socketTimeout.getKeyName(), String.valueOf(this.failoverSocketTimeoutMs));
@@ -506,21 +505,23 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         properties);
   }
 
-  protected synchronized void createConnectionAndInitializeTopology(ConnectionUrl connUrl) throws SQLException {
-    createInitialConnection(connUrl);
-    initTopology();
-    if (this.isFailoverEnabled()) {
-      validateInitialConnection();
+  protected void createConnectionAndInitializeTopology(ConnectionUrl connUrl) throws SQLException {
+    synchronized (this.lockObject) {
+      createInitialConnection(connUrl);
+      initTopology();
+      if (this.isFailoverEnabled()) {
+        validateInitialConnection();
 
-      if(this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
-        HostInfo currentHost = this.hosts.get(this.currentHostIndex);
-        if (isExplicitlyReadOnly()) {
-          topologyService.setLastUsedReaderHost(currentHost);
+        if (this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+          HostInfo currentHost = this.hosts.get(this.currentHostIndex);
+          if (isExplicitlyReadOnly()) {
+            topologyService.setLastUsedReaderHost(currentHost);
+          }
         }
-      }
 
-      this.currentConnection.getPropertySet().getIntegerProperty(PropertyKey.socketTimeout).setValue(this.failoverSocketTimeoutMs);
-      ((NativeSession) this.currentConnection.getSession()).setSocketTimeout(this.failoverSocketTimeoutMs);
+        this.currentConnection.getPropertySet().getIntegerProperty(PropertyKey.socketTimeout).setValue(this.failoverSocketTimeoutMs);
+        ((NativeSession) this.currentConnection.getSession()).setSocketTimeout(this.failoverSocketTimeoutMs);
+      }
     }
   }
 
@@ -528,7 +529,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     return this.explicitlyReadOnly != null && this.explicitlyReadOnly;
   }
 
-  private synchronized void createInitialConnection(ConnectionUrl connUrl) throws SQLException {
+  private void createInitialConnection(ConnectionUrl connUrl) throws SQLException {
     String host = connUrl.getMainHost().getHost();
     if (isRdsClusterDns(host)) {
       this.explicitlyReadOnly = isReaderClusterDns(host);
@@ -556,7 +557,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    *
    * @return true if there is a connection
    */
-  synchronized boolean isConnected() {
+  boolean isConnected() {
     return this.currentHostIndex != NO_CONNECTION_INDEX;
   }
 
@@ -636,8 +637,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     return (int) (Math.random() * ((max - min) + 1)) + min;
   }
 
-  private synchronized void initTopology() {
-    if(this.currentConnection != null) {
+  private void initTopology() {
+    if (this.currentConnection != null) {
       List<HostInfo> topology = this.topologyService.getTopology(this.currentConnection, false);
       if (!Util.isNullOrEmpty(topology)) {
         this.hosts = topology;
@@ -656,7 +657,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  private synchronized void validateInitialConnection() throws SQLException {
+  private void validateInitialConnection() throws SQLException {
     this.currentHostIndex = getHostIndex(topologyService.getHostByName(this.currentConnection));
     if (!isConnected()) {
       pickNewConnection();
@@ -702,30 +703,32 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * Local implementation for the new connection picker.
    */
   @Override
-  protected synchronized void pickNewConnection() throws SQLException {
-    if (this.isClosed && this.closedExplicitly) {
-      this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.14"));
-      releasePluginManager();
-      return;
-    }
-
-    if (isConnected() || Util.isNullOrEmpty(this.hosts)) {
-      failover(this.currentHostIndex);
-      return;
-    }
-
-    if (shouldAttemptReaderConnection()) {
-      failoverReader(NO_CONNECTION_INDEX);
-      return;
-    }
-
-    try {
-      connectTo(WRITER_CONNECTION_INDEX);
-      if (isExplicitlyReadOnly() && this.currentHostIndex != NO_CONNECTION_INDEX) {
-        topologyService.setLastUsedReaderHost(this.hosts.get(this.currentHostIndex));
+  protected void pickNewConnection() throws SQLException {
+    synchronized (this.lockObject) {
+      if (this.isClosed && this.closedExplicitly) {
+        this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.14"));
+        releasePluginManager();
+        return;
       }
-    } catch (SQLException e) {
-      failover(WRITER_CONNECTION_INDEX);
+
+      if (isConnected() || Util.isNullOrEmpty(this.hosts)) {
+        failover(this.currentHostIndex);
+        return;
+      }
+
+      if (shouldAttemptReaderConnection()) {
+        failoverReader(NO_CONNECTION_INDEX);
+        return;
+      }
+
+      try {
+        connectTo(WRITER_CONNECTION_INDEX);
+        if (isExplicitlyReadOnly() && this.currentHostIndex != NO_CONNECTION_INDEX) {
+          topologyService.setLastUsedReaderHost(this.hosts.get(this.currentHostIndex));
+        }
+      } catch (SQLException e) {
+        failover(WRITER_CONNECTION_INDEX);
+      }
     }
   }
 
@@ -750,29 +753,31 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @param hostIndex The host index in the global hosts list.
    * @throws SQLException if an error occurs
    */
-  private synchronized void connectTo(int hostIndex) throws SQLException {
-    try {
-      switchCurrentConnectionTo(hostIndex, createConnectionForHostIndex(hostIndex));
-      this.log.logDebug(
-          Messages.getString(
-              "ClusterAwareConnectionProxy.15", new Object[] {this.hosts.get(hostIndex)}));
-    } catch (SQLException e) {
-      if (this.currentConnection != null) {
-        HostInfo host = this.hosts.get(hostIndex);
-        StringBuilder msg =
-            new StringBuilder("Connection to ")
-                .append(isWriterHostIndex(hostIndex) ? "writer" : "reader")
-                .append(" host '")
-                .append(host == null ? "<null>" : host.getHostPortPair())
-                .append("' failed");
-        try {
-          this.log.logWarn(msg.toString(), e);
-        } catch (CJException ex) {
-          throw SQLExceptionsMapping.translateException(
-              e, this.currentConnection.getExceptionInterceptor());
+  private void connectTo(int hostIndex) throws SQLException {
+    synchronized (this.lockObject) {
+      try {
+        switchCurrentConnectionTo(hostIndex, createConnectionForHostIndex(hostIndex));
+        this.log.logDebug(
+            Messages.getString(
+                "ClusterAwareConnectionProxy.15", new Object[]{this.hosts.get(hostIndex)}));
+      } catch (SQLException e) {
+        if (this.currentConnection != null) {
+          HostInfo host = this.hosts.get(hostIndex);
+          StringBuilder msg =
+              new StringBuilder("Connection to ")
+                  .append(isWriterHostIndex(hostIndex) ? "writer" : "reader")
+                  .append(" host '")
+                  .append(host == null ? "<null>" : host.getHostPortPair())
+                  .append("' failed");
+          try {
+            this.log.logWarn(msg.toString(), e);
+          } catch (CJException ex) {
+            throw SQLExceptionsMapping.translateException(
+                e, this.currentConnection.getExceptionInterceptor());
+          }
         }
+        throw e;
       }
-      throw e;
     }
   }
 
@@ -782,7 +787,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @param hostIndex The host index in the global hosts list.
    * @return true if so
    */
-  private synchronized boolean isWriterHostIndex(int hostIndex) {
+  private boolean isWriterHostIndex(int hostIndex) {
     return hostIndex == WRITER_CONNECTION_INDEX;
   }
 
@@ -794,7 +799,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @param connection The connection instance to switch to.
    * @throws SQLException if an error occurs
    */
-  private synchronized void switchCurrentConnectionTo(int hostIndex, JdbcConnection connection)
+  private void switchCurrentConnectionTo(int hostIndex, JdbcConnection connection)
       throws SQLException {
     invalidateCurrentConnection();
 
@@ -821,7 +826,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @return The new connection instance.
    * @throws SQLException if an error occurs
    */
-  private synchronized ConnectionImpl createConnectionForHostIndex(int hostIndex)
+  private ConnectionImpl createConnectionForHostIndex(int hostIndex)
       throws SQLException {
     return createConnectionForHost(this.hosts.get(hostIndex));
   }
@@ -834,7 +839,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws SQLException if an error occurs
    */
   @Override
-  protected synchronized ConnectionImpl createConnectionForHost(HostInfo baseHostInfo)
+  protected ConnectionImpl createConnectionForHost(HostInfo baseHostInfo)
       throws SQLException {
     HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(baseHostInfo, this.initialConnectionProps);
     ConnectionImpl conn = this.connectionProvider.connect(hostInfoWithInitialProps);
@@ -854,29 +859,31 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @param failedHostIdx The index of the host that failed
    * @throws SQLException if an error occurs
    */
-  protected synchronized void failover(int failedHostIdx) throws SQLException {
-    if (shouldPerformWriterFailover()) {
-      failoverWriter();
-    } else {
-      failoverReader(failedHostIdx);
-    }
+  protected void failover(int failedHostIdx) throws SQLException {
+    synchronized (this.lockObject) {
+      if (shouldPerformWriterFailover()) {
+        failoverWriter();
+      } else {
+        failoverReader(failedHostIdx);
+      }
 
-    if (this.inTransaction) {
-      this.inTransaction = false;
+      if (this.inTransaction) {
+        this.inTransaction = false;
 
-      // "Transaction resolution unknown. Please re-configure session state if required and try
-      // restarting transaction."
-      this.log.logError(Messages.getString("ClusterAwareConnectionProxy.1"));
-      throw new SQLException(
-          Messages.getString("ClusterAwareConnectionProxy.1"),
-          MysqlErrorNumbers.SQL_STATE_TRANSACTION_RESOLUTION_UNKNOWN);
-    } else {
-      // "The active SQL connection has changed due to a connection failure. Please re-configure
-      // session state if required."
-      this.log.logError(Messages.getString("ClusterAwareConnectionProxy.3"));
-      throw new SQLException(
-          Messages.getString("ClusterAwareConnectionProxy.3"),
-          MysqlErrorNumbers.SQL_STATE_COMMUNICATION_LINK_CHANGED);
+        // "Transaction resolution unknown. Please re-configure session state if required and try
+        // restarting transaction."
+        this.log.logError(Messages.getString("ClusterAwareConnectionProxy.1"));
+        throw new SQLException(
+            Messages.getString("ClusterAwareConnectionProxy.1"),
+            MysqlErrorNumbers.SQL_STATE_TRANSACTION_RESOLUTION_UNKNOWN);
+      } else {
+        // "The active SQL connection has changed due to a connection failure. Please re-configure
+        // session state if required."
+        this.log.logError(Messages.getString("ClusterAwareConnectionProxy.3"));
+        throw new SQLException(
+            Messages.getString("ClusterAwareConnectionProxy.3"),
+            MysqlErrorNumbers.SQL_STATE_COMMUNICATION_LINK_CHANGED);
+      }
     }
   }
 
@@ -919,7 +926,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
             new Object[] {this.hosts.get(this.currentHostIndex)}));
   }
 
-  private synchronized void processFailoverFailure(String message) throws SQLException {
+  private void processFailoverFailure(String message) throws SQLException {
     if (this.gatherPerfMetricsSetting) {
       this.metrics.registerFailoverConnects(false);
     }
@@ -1026,7 +1033,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    *
    * @return true if the proxy is connected to a cluster using RDS proxy
    */
-  public synchronized boolean isRdsProxy() {
+  public boolean isRdsProxy() {
     return this.isRdsProxy;
   }
 
@@ -1084,21 +1091,23 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   @Override
-  public synchronized Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-    this.invokeStartTimeMs = this.gatherPerfMetricsSetting ? System.currentTimeMillis() : 0;
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    synchronized (this.lockObject) {
+      this.invokeStartTimeMs = this.gatherPerfMetricsSetting ? System.currentTimeMillis() : 0;
 
-    Object result = super.invoke(proxy, method, args);
+      Object result = super.invoke(proxy, method, args);
 
-    if (METHOD_CLOSE.equals(method.getName())) {
-      if (this.gatherPerfMetricsSetting) {
-        this.metrics.reportMetrics(this.log);
-        if (this.topologyService instanceof CanCollectPerformanceMetrics) {
-          ((CanCollectPerformanceMetrics) this.topologyService).reportMetrics(this.log);
+      if (METHOD_CLOSE.equals(method.getName())) {
+        if (this.gatherPerfMetricsSetting) {
+          this.metrics.reportMetrics(this.log);
+          if (this.topologyService instanceof CanCollectPerformanceMetrics) {
+            ((CanCollectPerformanceMetrics) this.topologyService).reportMetrics(this.log);
+          }
         }
       }
-    }
 
-    return result;
+      return result;
+    }
   }
 
   /**
@@ -1106,7 +1115,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * This is the continuation of MultiHostConnectionProxy#invoke(Object, Method, Object[]).
    */
   @Override
-  public synchronized Object invokeMore(Object proxy, Method method, Object[] args)
+  protected Object invokeMore(Object proxy, Method method, Object[] args)
       throws Throwable {
     final String methodName = method.getName();
 
@@ -1118,7 +1127,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     Object result = null;
     try {
-      result = this.pluginManager.execute(methodName, () -> method.invoke(this.thisAsConnection, args));
+      result = this.pluginManager.execute(this.thisAsConnection.getClass(), methodName, () -> method.invoke(this.thisAsConnection, args));
       result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
     } catch (InvocationTargetException e) {
       dealWithInvocationException(e);
@@ -1130,7 +1139,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     return result;
   }
 
-  private synchronized void invalidInvocationOnClosedConnection() throws SQLException {
+  private void invalidInvocationOnClosedConnection() throws SQLException {
     if (this.autoReconnect && !this.closedExplicitly) {
       this.currentHostIndex = NO_CONNECTION_INDEX; // Act as if this is the first connection but let it sync with the previous one.
       this.isClosed = false;
@@ -1162,7 +1171,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws InvocationTargetException if an error occurs
    */
   @Override
-  protected synchronized void dealWithInvocationException(InvocationTargetException e)
+  protected void dealWithInvocationException(InvocationTargetException e)
       throws SQLException, Throwable, InvocationTargetException {
     dealWithOriginalException(e.getTargetException(), e);
   }
@@ -1171,7 +1180,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     dealWithOriginalException(e.getCause(), e);
   }
 
-  private synchronized void dealWithOriginalException(Throwable originalException, Exception wrapperException) throws Throwable {
+  private void dealWithOriginalException(Throwable originalException, Exception wrapperException) throws Throwable {
     if (originalException != null) {
       this.log.logTrace(Messages.getString("ClusterAwareConnectionProxy.12"), originalException);
       if (this.lastExceptionDealtWith != originalException && shouldExceptionTriggerConnectionSwitch(originalException)) {
@@ -1230,7 +1239,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws SQLException if an error occurs
    */
   @Override
-  protected synchronized void invalidateCurrentConnection() throws SQLException {
+  protected void invalidateCurrentConnection() throws SQLException {
     if (this.inTransaction) {
       try {
         this.currentConnection.rollback();
@@ -1282,9 +1291,22 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws SQLException if an error occurs
    */
   @Override
-  protected synchronized void doClose() throws SQLException {
-    this.currentConnection.close();
-    releasePluginManager();
+  protected void doClose() throws SQLException {
+    synchronized (this.lockObject) {
+      try {
+        this.pluginManager.execute(this.getClass(), "close", () -> {
+          this.currentConnection.close();
+          return null;
+        });
+      }
+      catch(SQLException sqlEx) {
+        throw sqlEx;
+      }
+      catch(Exception ex) {
+        throw new SQLException(ex.getMessage(), ex);
+      }
+      releasePluginManager();
+    }
   }
 
   /**
@@ -1293,8 +1315,22 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws SQLException if an error occurs
    */
   @Override
-  protected synchronized void doAbort(Executor executor) throws SQLException {
-    this.currentConnection.abort(executor);
+  protected void doAbort(Executor executor) throws SQLException {
+    synchronized (this.lockObject) {
+      try {
+        this.pluginManager.execute(this.getClass(), "abort", () -> {
+          this.currentConnection.abort(executor);
+          return null;
+        });
+      }
+      catch(SQLException sqlEx) {
+        throw sqlEx;
+      }
+      catch(Exception ex) {
+        throw new SQLException(ex.getMessage(), ex);
+      }
+      releasePluginManager();
+    }
   }
 
   /**
@@ -1303,8 +1339,22 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    * @throws SQLException if an error occurs
    */
   @Override
-  protected synchronized void doAbortInternal() throws SQLException {
-    this.currentConnection.abortInternal();
+  protected void doAbortInternal() throws SQLException {
+    synchronized (this.lockObject) {
+      try {
+        this.pluginManager.execute(this.getClass(), "abortInternal", () -> {
+          this.currentConnection.abortInternal();
+          return null;
+        });
+      }
+      catch(SQLException sqlEx) {
+        throw sqlEx;
+      }
+      catch(Exception ex) {
+        throw new SQLException(ex.getMessage(), ex);
+      }
+      releasePluginManager();
+    }
   }
 
   @Override
@@ -1314,7 +1364,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
   /** Checks if current connection is to a master (writer) host. */
   @Override
-  protected synchronized boolean isSourceConnection() {
+  protected boolean isSourceConnection() {
     return isWriterHostIndex(this.currentHostIndex);
   }
 
@@ -1323,11 +1373,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     return new ClusterAwareConnectionLifecycleInterceptor(this);
   }
 
-  protected synchronized boolean isCurrentConnectionReadOnly() {
+  protected boolean isCurrentConnectionReadOnly() {
     return isConnected() && !isWriterHostIndex(this.currentHostIndex);
   }
 
-  protected synchronized boolean isCurrentConnectionWriter() {
+  protected boolean isCurrentConnectionWriter() {
     return isWriterHostIndex(this.currentHostIndex);
   }
 
@@ -1340,7 +1390,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    *
    * @return true if proxy is connected to cluster that can report its topology
    */
-  public synchronized boolean isClusterTopologyAvailable() {
+  public boolean isClusterTopologyAvailable() {
     return this.isClusterTopologyAvailable;
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -106,8 +106,8 @@ public class ConnectionPluginManager {
 
   //TODO: Should method target to be passed along with method name? Like:
   // Object execute(Object methodTarget, String methodName, Callable executeSqlFunc)
-  public Object execute(String methodName, Callable executeSqlFunc) throws Exception {
-    return this.headPlugin.execute(methodName, executeSqlFunc);
+  public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+    return this.headPlugin.execute(methodInvokeOn, methodName, executeSqlFunc);
   }
 
   public void releaseResources() {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -99,14 +99,7 @@ public class ConnectionPluginManager {
 
   }
 
-  //TODO: Should methodName contain not just method name but also an interface name? Like:
-  // "execute" -> "JdbcConnection.execute"
-  // For example method close() exists for Connection, Statement, ResultSet and Closeable interfaces. Thus it might be challenging for a plugin to identify what
-  // exact method is actually been called.
-
-  //TODO: Should method target to be passed along with method name? Like:
-  // Object execute(Object methodTarget, String methodName, Callable executeSqlFunc)
-  public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     return this.headPlugin.execute(methodInvokeOn, methodName, executeSqlFunc);
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -17,7 +17,7 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   }
 
   @Override
-  public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
     this.log.logTrace(
         String.format("[DefaultConnectionPlugin.execute]: method=%s.%s >>>>>", methodInvokeOn.getName(), methodName));
     try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -17,7 +17,7 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   }
 
   @Override
-  public Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     this.log.logTrace(
         String.format("[DefaultConnectionPlugin.execute]: method=%s.%s >>>>>", methodInvokeOn.getName(), methodName));
     try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -17,7 +17,7 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   }
 
   @Override
-  public Object execute(String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
     this.log.logTrace(
         String.format("[DefaultConnectionPlugin.execute]: method=%s >>>>>", methodName));
     try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -19,16 +19,16 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   @Override
   public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
     this.log.logTrace(
-        String.format("[DefaultConnectionPlugin.execute]: method=%s >>>>>", methodName));
+        String.format("[DefaultConnectionPlugin.execute]: method=%s.%s >>>>>", methodInvokeOn.getName(), methodName));
     try {
       return executeSqlFunc.call();
     } catch (Exception ex) {
       this.log.logTrace(
-          String.format("[DefaultConnectionPlugin.execute]: method=%s, exception: ", methodName), ex);
+          String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ", methodInvokeOn.getName(), methodName), ex);
       throw ex;
     } finally {
       this.log.logTrace(
-          String.format("[DefaultConnectionPlugin.execute]: method=%s <<<<<", methodName));
+          String.format("[DefaultConnectionPlugin.execute]: method=%s.%s <<<<<", methodInvokeOn.getName(), methodName));
     }
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
@@ -29,6 +29,6 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import java.util.concurrent.Callable;
 
 public interface IConnectionPlugin {
-  Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception;
+  Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception;
   void releaseResources();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
@@ -29,6 +29,6 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import java.util.concurrent.Callable;
 
 public interface IConnectionPlugin {
-  Object execute(String methodName, Callable executeSqlFunc) throws Exception;
+  Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception;
   void releaseResources();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
@@ -29,6 +29,6 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import java.util.concurrent.Callable;
 
 public interface IConnectionPlugin {
-  Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception;
+  Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception;
   void releaseResources();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -139,8 +139,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     ExecutorService executor = null;
     try {
       this.log.logTrace(String.format(
-          "[NodeMonitoringConnectionPlugin.execute]: method=%s, monitoring is activated",
-          methodName));
+          "[NodeMonitoringConnectionPlugin.execute]: method=%s.%s, monitoring is activated",
+              methodInvokeOn.getName(), methodName));
 
       checkNewConnection(this.proxy.getCurrentConnection());
 
@@ -180,8 +180,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
         executor.shutdownNow();
       }
       this.log.logTrace(String.format(
-          "[NodeMonitoringConnectionPlugin.execute]: method=%s, monitoring is deactivated",
-          methodName));
+          "[NodeMonitoringConnectionPlugin.execute]: method=%s.%s, monitoring is deactivated",
+              methodInvokeOn.getName(), methodName));
     }
 
     return result;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -111,7 +111,7 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
    * @throws Exception if an error occurs.
    */
   @Override
-  public Object execute(Class methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
     // update config settings since they may change
     final boolean isEnabled = this.propertySet
         .getBooleanProperty(PropertyKey.nativeFailureDetectionEnabled)

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -194,7 +194,7 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     // boolean isJdbcStatement = Statement.class.isAssignableFrom(methodInvokeOn);
     // boolean isJdbcResultSet = ResultSet.class.isAssignableFrom(methodInvokeOn);
 
-    if (methodName == "close" || methodName.startsWith("get")) {
+    if ("close".equals(methodName) || methodName.startsWith("get") || methodName.startsWith("abort")) {
       return false;
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -111,13 +111,13 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
    * @throws Exception if an error occurs.
    */
   @Override
-  public Object execute(Class<?> methodInvokeOn, String methodName, Callable executeSqlFunc) throws Exception {
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     // update config settings since they may change
     final boolean isEnabled = this.propertySet
         .getBooleanProperty(PropertyKey.nativeFailureDetectionEnabled)
         .getValue();
 
-    if (!isEnabled || !this.isNeedMonitoring(methodInvokeOn, methodName)) {
+    if (!isEnabled || !this.doesNeedMonitoring(methodInvokeOn, methodName)) {
       // do direct call
       return this.nextPlugin.execute(methodInvokeOn, methodName, executeSqlFunc);
     }
@@ -187,7 +187,7 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     return result;
   }
 
-  protected boolean isNeedMonitoring(Class methodInvokeOn, String methodName) {
+  protected boolean doesNeedMonitoring(Class<?> methodInvokeOn, String methodName) {
     // It's possible to use the following, or similar, expressions to verify method invocation class
     //
     // boolean isJdbcConnection = JdbcConnection.class.isAssignableFrom(methodInvokeOn) || ClusterAwareConnectionProxy.class.isAssignableFrom(methodInvokeOn);

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultithreadedNodeMonitoringConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MultithreadedNodeMonitoringConnectionPluginTest.java
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Multi-threaded tests for {@link NodeMonitoringConnectionPlugin#execute(String, Callable)}.
+ * Multi-threaded tests for {@link NodeMonitoringConnectionPlugin#execute(Class, String, Callable)}.
  */
 public class MultithreadedNodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginBaseTest {
   private final AtomicInteger counter = new AtomicInteger(0);
@@ -138,7 +138,7 @@ public class MultithreadedNodeMonitoringConnectionPluginTest extends NodeMonitor
   @RepeatedTest(value = 100, name = "execute with exception")
   void test_2_executeWithException() throws Exception {
     when(context.isNodeUnhealthy()).thenReturn(true);
-    when(mockPlugin.execute(anyString(), eq(sqlFunction))).thenAnswer(invocation -> {
+    when(mockPlugin.execute(any(Class.class), anyString(), eq(sqlFunction))).thenAnswer(invocation -> {
       // Sleep for a while to imitate a long query
       // and allow the monitoring thread time to check node status.
       Thread.sleep(60 * 1000);
@@ -229,7 +229,7 @@ public class MultithreadedNodeMonitoringConnectionPluginTest extends NodeMonitor
             concurrentCounter.getAndIncrement();
           }
 
-          final Object result = plugin.execute(NodeMonitoringConnectionPluginBaseTest.MONITOR_METHOD_NAME, sqlFunction);
+          final Object result = plugin.execute(MONITOR_METHOD_INVOKE_ON, NodeMonitoringConnectionPluginBaseTest.MONITOR_METHOD_NAME, sqlFunction);
           counter.getAndDecrement();
           return result;
         } catch (Exception e) {

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginBaseTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginBaseTest.java
@@ -36,6 +36,7 @@ import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.conf.RuntimeProperty;
+import com.mysql.cj.jdbc.JdbcConnection;
 import com.mysql.cj.jdbc.ha.ca.ClusterAwareConnectionProxy;
 import com.mysql.cj.log.Log;
 import org.mockito.Mock;
@@ -68,6 +69,7 @@ public class NodeMonitoringConnectionPluginBaseTest {
   @Mock RuntimeProperty<Integer> failureDetectionCountProperty;
 
   static final String NODE = "node";
+  static final Class MONITOR_METHOD_INVOKE_ON = JdbcConnection.class;
   static final String MONITOR_METHOD_NAME = "executeQuery";
   static final String NO_MONITOR_METHOD_NAME = "foo";
   static final int FAILURE_DETECTION_TIME = 10;
@@ -88,7 +90,7 @@ public class NodeMonitoringConnectionPluginBaseTest {
         anyInt()))
         .thenReturn(context);
 
-    when(mockPlugin.execute(anyString(), Mockito.any(Callable.class))).thenReturn("done");
+    when(mockPlugin.execute(any(Class.class), anyString(), Mockito.any(Callable.class))).thenReturn("done");
 
     when(proxy.getCurrentConnection()).thenReturn(connection);
     when(proxy.getCurrentHostInfo()).thenReturn(hostInfo);

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginTest.java
@@ -93,10 +93,10 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
         .thenReturn(Boolean.FALSE);
 
     initializePlugin();
-    plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
+    plugin.execute(MONITOR_METHOD_INVOKE_ON, MONITOR_METHOD_NAME, sqlFunction);
 
     verify(initializer, never()).create(any());
-    verify(mockPlugin).execute(eq(MONITOR_METHOD_NAME), eq(sqlFunction));
+    verify(mockPlugin).execute(any(Class.class), eq(MONITOR_METHOD_NAME), eq(sqlFunction));
   }
 
   @Test
@@ -105,10 +105,10 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
         .thenReturn(Boolean.TRUE);
 
     initializePlugin();
-    plugin.execute(NO_MONITOR_METHOD_NAME, sqlFunction);
+    plugin.execute(MONITOR_METHOD_INVOKE_ON, NO_MONITOR_METHOD_NAME, sqlFunction);
 
     verify(initializer, atMostOnce()).create(logger);
-    verify(mockPlugin).execute(eq(NO_MONITOR_METHOD_NAME), eq(sqlFunction));
+    verify(mockPlugin).execute(any(Class.class), eq(NO_MONITOR_METHOD_NAME), eq(sqlFunction));
   }
 
   @Test
@@ -119,10 +119,10 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
     initializePlugin();
 
     assertThrows(Exception.class, () -> {
-      when(mockPlugin.execute(any(), any()))
+      when(mockPlugin.execute(any(Class.class), any(), any()))
           .thenThrow(EXECUTION_EXCEPTION);
 
-      plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
+      plugin.execute(MONITOR_METHOD_INVOKE_ON, MONITOR_METHOD_NAME, sqlFunction);
     });
 
     verify(monitorService).stopMonitoring(eq(context));
@@ -139,14 +139,14 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
       when(context.isNodeUnhealthy())
           .thenReturn(Boolean.TRUE);
 
-      when(mockPlugin.execute(any(), any()))
+      when(mockPlugin.execute(any(Class.class), any(), any()))
           .thenAnswer(invocation -> {
             // Imitate running a long query;
             Thread.sleep(60 * 1000);
             return "done";
           });
 
-      plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
+      plugin.execute(MONITOR_METHOD_INVOKE_ON, MONITOR_METHOD_NAME, sqlFunction);
     });
 
     verify(context).isNodeUnhealthy();
@@ -161,7 +161,7 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
         .thenReturn(Boolean.TRUE);
     when(context.isNodeUnhealthy())
         .thenReturn(Boolean.FALSE);
-    when(mockPlugin.execute(any(), any()))
+    when(mockPlugin.execute(any(Class.class), any(), any()))
         .thenAnswer(invocation -> {
           // Imitate running a query for 10 seconds.
           Thread.sleep(10 * 1000);
@@ -169,7 +169,7 @@ class NodeMonitoringConnectionPluginTest extends NodeMonitoringConnectionPluginB
         });
 
     initializePlugin();
-    final Object result = plugin.execute(MONITOR_METHOD_NAME, sqlFunction);
+    final Object result = plugin.execute(MONITOR_METHOD_INVOKE_ON, MONITOR_METHOD_NAME, sqlFunction);
 
     assertEquals(expected, result);
     verify(context, atLeastOnce()).isNodeUnhealthy();


### PR DESCRIPTION
### Summary

FailoverPluginManager.execute() Method Signature Changes

### Description

FailoverPluginManager.execute() method signature currently lacks identifiability to other class’ execute() methods. Adding interface name to method signature can help uniquely identify it from others.

### Additional Reviewers

@matthewh-BQ 
@karenc-bq 
@ColinKYuen 
@brunos-bq 