### PR TITLE
fix: add `next` to list of methods not requiring monitoring

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -37,7 +37,10 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -194,8 +197,18 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     // boolean isJdbcStatement = Statement.class.isAssignableFrom(methodInvokeOn);
     // boolean isJdbcResultSet = ResultSet.class.isAssignableFrom(methodInvokeOn);
 
-    if ("close".equals(methodName) || methodName.startsWith("get") || methodName.startsWith("abort")) {
-      return false;
+    final List<String> methodsStartingWith = Arrays.asList("get", "abort");
+    for (final String method : methodsStartingWith) {
+      if (methodName.startsWith(method)) {
+        return false;
+      }
+    }
+
+    final List<String> methodsEqualTo = Arrays.asList("close", "next");
+    for (final String method : methodsEqualTo) {
+      if (method.equals(methodName)) {
+        return false;
+      }
     }
 
     // Monitor all other methods

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -37,7 +37,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +52,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
 
   static final int CHECK_INTERVAL_MILLIS = 1000;
   private static final String RETRIEVE_HOST_PORT_SQL = "SELECT CONCAT(@@hostname, ':', @@port)";
+  private static final List<String> METHODS_STARTING_WITH = Arrays.asList("get", "abort");
+  private static final List<String> METHODS_EQUAL_TO = Arrays.asList("close", "next");
 
   protected IConnectionPlugin nextPlugin;
   protected Log log;
@@ -197,15 +198,13 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     // boolean isJdbcStatement = Statement.class.isAssignableFrom(methodInvokeOn);
     // boolean isJdbcResultSet = ResultSet.class.isAssignableFrom(methodInvokeOn);
 
-    final List<String> methodsStartingWith = Arrays.asList("get", "abort");
-    for (final String method : methodsStartingWith) {
+    for (final String method : METHODS_STARTING_WITH) {
       if (methodName.startsWith(method)) {
         return false;
       }
     }
 
-    final List<String> methodsEqualTo = Arrays.asList("close", "next");
-    for (final String method : methodsEqualTo) {
+    for (final String method : METHODS_EQUAL_TO) {
       if (method.equals(methodName)) {
         return false;
       }


### PR DESCRIPTION
### Summary

Do not monitor `ResultSetImpl::next`.
https://bitquill.atlassian.net/browse/RDS-554

### Description

It is still uncertain why monitoring `next` would result in driver unable to finish execution; however, the implementation of `next` does not make any calls to the server, so we shouldn't need to monitor it.

### Additional Reviewers
@sergiyv-bitquill 
@ColinKYuen