### PR TITLE
refactor: MonitorThreadContainer get/release

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
@@ -46,6 +46,7 @@ public class MonitorThreadContainer {
     private final Map<IMonitor, Future<?>> tasksMap = new ConcurrentHashMap<>();
     private final Queue<IMonitor> availableMonitors = new ConcurrentLinkedDeque<>();
     private final ExecutorService threadPool;
+    private static final Object lockObject = new Object();
 
     public static MonitorThreadContainer getInstance() {
         return getInstance(Executors::newCachedThreadPool);
@@ -53,7 +54,7 @@ public class MonitorThreadContainer {
 
     static MonitorThreadContainer getInstance(IExecutorServiceInitializer executorServiceInitializer) {
         if (singleton == null) {
-            synchronized (singleton) {
+            synchronized (lockObject) {
                 singleton = new MonitorThreadContainer(executorServiceInitializer);
             }
             CLASS_USAGE_COUNT.set(0);
@@ -68,7 +69,7 @@ public class MonitorThreadContainer {
         }
 
         if (CLASS_USAGE_COUNT.decrementAndGet() <= 0) {
-            synchronized (singleton) {
+            synchronized (lockObject) {
                 singleton.releaseResources();
                 singleton = null;
             }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
@@ -46,7 +46,7 @@ public class MonitorThreadContainer {
     private final Map<IMonitor, Future<?>> tasksMap = new ConcurrentHashMap<>();
     private final Queue<IMonitor> availableMonitors = new ConcurrentLinkedDeque<>();
     private final ExecutorService threadPool;
-    private static final Object lockObject = new Object();
+    private static final Object LOCK_OBJECT = new Object();
 
     public static MonitorThreadContainer getInstance() {
         return getInstance(Executors::newCachedThreadPool);
@@ -54,7 +54,7 @@ public class MonitorThreadContainer {
 
     static MonitorThreadContainer getInstance(IExecutorServiceInitializer executorServiceInitializer) {
         if (singleton == null) {
-            synchronized (lockObject) {
+            synchronized (LOCK_OBJECT) {
                 singleton = new MonitorThreadContainer(executorServiceInitializer);
             }
             CLASS_USAGE_COUNT.set(0);
@@ -69,7 +69,7 @@ public class MonitorThreadContainer {
         }
 
         if (CLASS_USAGE_COUNT.decrementAndGet() <= 0) {
-            synchronized (lockObject) {
+            synchronized (LOCK_OBJECT) {
                 singleton.releaseResources();
                 singleton = null;
             }


### PR DESCRIPTION
### Summary

MonitorThreadContainer executor get/release

### Description

- Use of object locks instead of synchronizing whole method block for getting and releasing singleton MonitorThreadContainer.
- Added null check for Monitor in `releaseResource(IMonitor monitor)`.

### Additional Reviewers

@sergiyv-bitquill 
@karenc-bq 