### PR TITLE
refactor: Simplifying Supplier Lambda

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -145,7 +145,6 @@ public class DefaultMonitorService implements IMonitorService {
   }
 
   protected IMonitor getMonitor(Set<String> nodeKeys, HostInfo hostInfo, PropertySet propertySet) {
-    final Supplier<IMonitor> monitorCreate = () -> monitorInitializer.createMonitor(hostInfo, propertySet, this);
-    return this.threadContainer.getOrCreateMonitor(nodeKeys, monitorCreate);
+    return this.threadContainer.getOrCreateMonitor(nodeKeys, () -> monitorInitializer.createMonitor(hostInfo, propertySet, this));
   }
 }


### PR DESCRIPTION


### Summary

refactor: Simplifying Supplier Lambda

### Description

Moved supplier lambda into method parameter.

For "clearing contexts when doing failover", it should still do this based on the latest changes in No-threads #62 as when a failover occurs, the connection is aborted.

### Additional Reviewers

@karenc-bq @sergiyv-bitquill @matthewh-BQ 