### PR TITLE
Address checkstyle warnings

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -107,7 +107,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   protected transient Log log = NULL_LOGGER;
 
   protected static final int NO_CONNECTION_INDEX = -1;
-  protected static final int WRITER_CONNECTION_INDEX = 0; // writer host is always stored at index 0
+  protected static final int WRITER_CONNECTION_INDEX = 0;
+  // writer host is always stored at index 0
 
   protected int currentHostIndex = NO_CONNECTION_INDEX;
   protected Map<String, String> initialConnectionProps;
@@ -164,7 +165,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         Object result = null;
 
         try {
-          result = ClusterAwareConnectionProxy.this.pluginManager.execute(this.invokeOn.getClass(), method.getName(), () -> method.invoke(this.invokeOn, args));
+          result =
+              ClusterAwareConnectionProxy.this.pluginManager.execute(
+                  this.invokeOn.getClass(),
+                  method.getName(),
+                  () -> method.invoke(this.invokeOn, args));
           result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
         } catch (InvocationTargetException e) {
           dealWithInvocationException(e);
@@ -189,7 +194,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   public static JdbcConnection autodetectClusterAndCreateProxyInstance(ConnectionUrl connectionUrl)
       throws SQLException {
 
-    ClusterAwareConnectionProxy connProxy = new ClusterAwareConnectionProxy(connectionUrl);
+    ClusterAwareConnectionProxy connProxy =
+        new ClusterAwareConnectionProxy(connectionUrl);
 
     if (connProxy.isFailoverEnabled()) {
       return (JdbcConnection)
@@ -225,7 +231,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
    */
   public static JdbcConnection createProxyInstance(ConnectionUrl connectionUrl)
       throws SQLException {
-    ClusterAwareConnectionProxy connProxy = new ClusterAwareConnectionProxy(connectionUrl);
+    ClusterAwareConnectionProxy connProxy =
+        new ClusterAwareConnectionProxy(connectionUrl);
     return (JdbcConnection)
         java.lang.reflect.Proxy.newProxyInstance(
             JdbcConnection.class.getClassLoader(),
@@ -318,21 +325,30 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     this.failoverTimeoutMsSetting =
         connProps.getIntegerProperty(PropertyKey.failoverTimeoutMs).getValue();
     this.failoverClusterTopologyRefreshRateMsSetting =
-        connProps.getIntegerProperty(PropertyKey.failoverClusterTopologyRefreshRateMs).getValue();
+        connProps
+            .getIntegerProperty(PropertyKey.failoverClusterTopologyRefreshRateMs)
+            .getValue();
     this.failoverWriterReconnectIntervalMsSetting =
-        connProps.getIntegerProperty(PropertyKey.failoverWriterReconnectIntervalMs).getValue();
+        connProps
+            .getIntegerProperty(PropertyKey.failoverWriterReconnectIntervalMs)
+            .getValue();
     this.failoverReaderConnectTimeoutMsSetting =
-        connProps.getIntegerProperty(PropertyKey.failoverReaderConnectTimeoutMs).getValue();
+        connProps
+            .getIntegerProperty(PropertyKey.failoverReaderConnectTimeoutMs)
+            .getValue();
     this.clusterIdSetting = connProps.getStringProperty(PropertyKey.clusterId).getValue();
     this.clusterInstanceHostPatternSetting =
         connProps.getStringProperty(PropertyKey.clusterInstanceHostPattern).getValue();
 
-    this.failoverConnectTimeoutMs = connProps.getIntegerProperty(PropertyKey.connectTimeout).getValue();
-    this.failoverSocketTimeoutMs = connProps.getIntegerProperty(PropertyKey.socketTimeout).getValue();
+    this.failoverConnectTimeoutMs =
+        connProps.getIntegerProperty(PropertyKey.connectTimeout).getValue();
+    this.failoverSocketTimeoutMs =
+        connProps.getIntegerProperty(PropertyKey.socketTimeout).getValue();
   }
 
   protected void initLogger(ConnectionUrl connUrl) {
-    String loggerClassName = connUrl.getOriginalProperties().get(PropertyKey.logger.getKeyName());
+    String loggerClassName =
+        connUrl.getOriginalProperties().get(PropertyKey.logger.getKeyName());
     if (!StringUtils.isNullOrEmpty(loggerClassName)) {
       this.log = LogFactory.getLogger(loggerClassName, Log.LOGGER_INSTANCE_NAME);
     }
@@ -355,11 +371,13 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.8"));
     this.log.logTrace(
         Messages.getString(
-            "ClusterAwareConnectionProxy.9", new Object[] {"clusterId", this.clusterIdSetting}));
+            "ClusterAwareConnectionProxy.9",
+            new Object[] {"clusterId", this.clusterIdSetting}));
     this.log.logTrace(
         Messages.getString(
             "ClusterAwareConnectionProxy.9",
-            new Object[] {"clusterInstanceHostPattern", this.clusterInstanceHostPatternSetting}));
+            new Object[] {"clusterInstanceHostPattern",
+                this.clusterInstanceHostPatternSetting}));
 
     this.mainHost = this.connectionUrl.getMainHost();
     if (!StringUtils.isNullOrEmpty(this.clusterInstanceHostPatternSetting)) {
@@ -384,10 +402,13 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  private void initFromHostPatternSetting(ConnectionUrl connUrl, HostInfo mainHost) throws SQLException {
-    ConnectionUrlParser.Pair<String, Integer> pair = getHostPortPairFromHostPatternSetting();
+  private void initFromHostPatternSetting(ConnectionUrl connUrl, HostInfo mainHost)
+      throws SQLException {
+    ConnectionUrlParser.Pair<String, Integer> pair =
+        getHostPortPairFromHostPatternSetting();
     String instanceHostPattern = pair.left;
-    int instanceHostPort = pair.right != HostInfo.NO_PORT ? pair.right : mainHost.getPort();
+    int instanceHostPort =
+        pair.right != HostInfo.NO_PORT ? pair.right : mainHost.getPort();
 
     // Instance host info is similar to original main host except host and port which come from the configuration property
     setClusterId(instanceHostPattern, instanceHostPort);
@@ -396,9 +417,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     createConnectionAndInitializeTopology(connUrl);
   }
 
-  private ConnectionUrlParser.Pair<String, Integer> getHostPortPairFromHostPatternSetting() throws SQLException {
-    ConnectionUrlParser.Pair<String, Integer> pair = ConnectionUrlParser.parseHostPortPair(
-        this.clusterInstanceHostPatternSetting);
+  private ConnectionUrlParser.Pair<String, Integer> getHostPortPairFromHostPatternSetting()
+      throws SQLException {
+    ConnectionUrlParser.Pair<String, Integer> pair =
+        ConnectionUrlParser.parseHostPortPair(
+            this.clusterInstanceHostPatternSetting);
     if (pair == null) {
       // "Invalid value for the 'clusterInstanceHostPattern' configuration setting - the value could not be parsed"
       throw new SQLException(Messages.getString("ClusterAwareConnectionProxy.5"));
@@ -437,15 +460,19 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   private void identifyRdsType(String host) {
     this.isRds = isRdsDns(host);
     this.log.logTrace(
-        Messages.getString("ClusterAwareConnectionProxy.10", new Object[] {"isRds", this.isRds}));
+        Messages.getString(
+            "ClusterAwareConnectionProxy.10",
+            new Object[] {"isRds", this.isRds}));
 
     this.isRdsProxy = isRdsProxyDns(host);
     this.log.logTrace(
         Messages.getString(
-            "ClusterAwareConnectionProxy.10", new Object[] {"isRdsProxy", this.isRdsProxy}));
+            "ClusterAwareConnectionProxy.10",
+            new Object[] {"isRdsProxy", this.isRdsProxy}));
   }
 
-  private void initExpectingNoTopology(ConnectionUrl connUrl, HostInfo mainHost) throws SQLException {
+  private void initExpectingNoTopology(ConnectionUrl connUrl, HostInfo mainHost)
+      throws SQLException {
     setClusterId(mainHost.getHost(), mainHost.getPort());
     this.topologyService.setClusterInstanceTemplate(
         createClusterInstanceTemplate(mainHost, mainHost.getHost(), mainHost.getPort()));
@@ -460,16 +487,20 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  private void initFromConnectionString(ConnectionUrl connUrl, HostInfo mainHost) throws SQLException {
+  private void initFromConnectionString(ConnectionUrl connUrl, HostInfo mainHost)
+      throws SQLException {
     String rdsInstanceHostPattern = getRdsInstanceHostPattern(mainHost.getHost());
-    if(rdsInstanceHostPattern == null) {
+    if (rdsInstanceHostPattern == null) {
       this.log.logError(Messages.getString("ClusterAwareConnectionProxy.20"));
       throw new SQLException(Messages.getString("ClusterAwareConnectionProxy.20"));
     }
 
     setClusterId(mainHost.getHost(), mainHost.getPort());
     this.topologyService.setClusterInstanceTemplate(
-        createClusterInstanceTemplate(mainHost, rdsInstanceHostPattern, mainHost.getPort()));
+        createClusterInstanceTemplate(
+            mainHost,
+            rdsInstanceHostPattern,
+            mainHost.getPort()));
     createConnectionAndInitializeTopology(connUrl);
   }
 
@@ -488,10 +519,17 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  private HostInfo createClusterInstanceTemplate(HostInfo mainHost, String host, int port) {
+  private HostInfo createClusterInstanceTemplate(
+      HostInfo mainHost,
+      String host,
+      int port) {
     Map<String, String> properties = new HashMap<>(this.initialConnectionProps);
-    properties.put(PropertyKey.connectTimeout.getKeyName(), String.valueOf(this.failoverConnectTimeoutMs));
-    properties.put(PropertyKey.socketTimeout.getKeyName(), String.valueOf(this.failoverSocketTimeoutMs));
+    properties.put(
+        PropertyKey.connectTimeout.getKeyName(),
+        String.valueOf(this.failoverConnectTimeoutMs));
+    properties.put(
+        PropertyKey.socketTimeout.getKeyName(),
+        String.valueOf(this.failoverSocketTimeoutMs));
 
     return new HostInfo(
         this.connectionUrl,
@@ -503,21 +541,26 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         properties);
   }
 
-  protected void createConnectionAndInitializeTopology(ConnectionUrl connUrl) throws SQLException {
+  protected void createConnectionAndInitializeTopology(ConnectionUrl connUrl)
+      throws SQLException {
     synchronized (this.lockObject) {
       createInitialConnection(connUrl);
       initTopology();
       if (this.isFailoverEnabled()) {
         validateInitialConnection();
 
-        if (this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+        if (this.currentHostIndex != NO_CONNECTION_INDEX
+            && !Util.isNullOrEmpty(this.hosts)) {
           HostInfo currentHost = this.hosts.get(this.currentHostIndex);
           if (isExplicitlyReadOnly()) {
             topologyService.setLastUsedReaderHost(currentHost);
           }
         }
 
-        this.currentConnection.getPropertySet().getIntegerProperty(PropertyKey.socketTimeout).setValue(this.failoverSocketTimeoutMs);
+        this.currentConnection
+            .getPropertySet()
+            .getIntegerProperty(PropertyKey.socketTimeout)
+            .setValue(this.failoverSocketTimeoutMs);
         ((NativeSession) this.currentConnection.getSession()).setSocketTimeout(this.failoverSocketTimeoutMs);
       }
     }
@@ -592,7 +635,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private int getCandidateIndexForInitialConnection() {
-    if(Util.isNullOrEmpty(this.hosts)) {
+    if (Util.isNullOrEmpty(this.hosts)) {
       return NO_CONNECTION_INDEX;
     }
 
@@ -637,7 +680,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
   private void initTopology() {
     if (this.currentConnection != null) {
-      List<HostInfo> topology = this.topologyService.getTopology(this.currentConnection, false);
+      List<HostInfo> topology =
+          this.topologyService.getTopology(this.currentConnection, false);
       if (!Util.isNullOrEmpty(topology)) {
         this.hosts = topology;
       }
@@ -656,7 +700,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private void validateInitialConnection() throws SQLException {
-    this.currentHostIndex = getHostIndex(topologyService.getHostByName(this.currentConnection));
+    this.currentHostIndex =
+        getHostIndex(topologyService.getHostByName(this.currentConnection));
     if (!isConnected()) {
       pickNewConnection();
       return;
@@ -737,7 +782,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
   @Override
   public HostInfo getCurrentHostInfo() {
-    return this.currentHostIndex != NO_CONNECTION_INDEX ? this.hosts.get(this.currentHostIndex) : mainHost;
+    return this.currentHostIndex != NO_CONNECTION_INDEX
+        ? this.hosts.get(this.currentHostIndex) : mainHost;
   }
 
   private boolean shouldAttemptReaderConnection() {
@@ -757,7 +803,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         switchCurrentConnectionTo(hostIndex, createConnectionForHostIndex(hostIndex));
         this.log.logDebug(
             Messages.getString(
-                "ClusterAwareConnectionProxy.15", new Object[]{this.hosts.get(hostIndex)}));
+                "ClusterAwareConnectionProxy.15",
+                new Object[] {this.hosts.get(hostIndex)}));
       } catch (SQLException e) {
         if (this.currentConnection != null) {
           HostInfo host = this.hosts.get(hostIndex);
@@ -839,7 +886,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   @Override
   protected ConnectionImpl createConnectionForHost(HostInfo baseHostInfo)
       throws SQLException {
-    HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(baseHostInfo, this.initialConnectionProps);
+    HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(
+        baseHostInfo,
+        this.initialConnectionProps);
     ConnectionImpl conn = this.connectionProvider.connect(hostInfoWithInitialProps);
     setConnectionProxy(conn);
     return conn;
@@ -895,7 +944,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     if (this.gatherPerfMetricsSetting) {
       long currentTimeMs = System.currentTimeMillis();
-      this.metrics.registerWriterFailoverProcedureTime(currentTimeMs - this.failoverStartTimeMs);
+      this.metrics.registerWriterFailoverProcedureTime(
+          currentTimeMs - this.failoverStartTimeMs);
       this.failoverStartTimeMs = 0;
     }
 
@@ -931,7 +981,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     this.log.logError(message);
     releasePluginManager();
-    throw new SQLException(message, MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE);
+    throw new SQLException(
+        message,
+        MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE);
   }
 
   protected void failoverReader(int failedHostIdx) throws SQLException {
@@ -945,7 +997,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     if (this.gatherPerfMetricsSetting) {
       long currentTimeMs = System.currentTimeMillis();
-      this.metrics.registerReaderFailoverProcedureTime(currentTimeMs - this.failoverStartTimeMs);
+      this.metrics.registerReaderFailoverProcedureTime(
+          currentTimeMs - this.failoverStartTimeMs);
       this.failoverStartTimeMs = 0;
     }
 
@@ -964,7 +1017,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     this.currentHostIndex = result.getConnectionIndex();
     updateTopologyAndConnectIfNeeded(true);
 
-    if(this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+    if (this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
       HostInfo currentHost = this.hosts.get(this.currentHostIndex);
       topologyService.setLastUsedReaderHost(currentHost);
       this.log.logDebug(
@@ -974,12 +1027,15 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
   }
 
-  protected void updateTopologyAndConnectIfNeeded(boolean forceUpdate) throws SQLException {
-    if (!isFailoverEnabled() || this.currentConnection == null || this.currentConnection.isClosed()) {
+  protected void updateTopologyAndConnectIfNeeded(boolean forceUpdate)
+      throws SQLException {
+    if (!isFailoverEnabled() || this.currentConnection == null
+        || this.currentConnection.isClosed()) {
       return;
     }
 
-    List<HostInfo> latestTopology = this.topologyService.getTopology(this.currentConnection, forceUpdate);
+    List<HostInfo> latestTopology =
+        this.topologyService.getTopology(this.currentConnection, forceUpdate);
     if (Util.isNullOrEmpty(latestTopology)) {
       return;
     }
@@ -1058,10 +1114,12 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     String clusterKeyword = getClusterKeyword(matcher);
     if ("cluster-".equalsIgnoreCase(clusterKeyword)
         || "cluster-ro-".equalsIgnoreCase(clusterKeyword)) {
-      return matcher.group(1) + ".cluster-" + matcher.group(3); // always RDS cluster endpoint
+      return matcher.group(1) + ".cluster-"
+          + matcher.group(3); // always RDS cluster endpoint
     }
     return null;
   }
+
   private boolean isRdsClusterDns(String host) {
     Matcher matcher = auroraDnsPattern.matcher(host);
     String clusterKeyword = getClusterKeyword(matcher);
@@ -1073,6 +1131,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     Matcher matcher = auroraDnsPattern.matcher(host);
     return "cluster-ro-".equalsIgnoreCase(getClusterKeyword(matcher));
   }
+
   private boolean isRdsCustomClusterDns(String host) {
     Matcher matcher = auroraCustomClusterPattern.matcher(host);
     return matcher.find();
@@ -1091,7 +1150,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
     synchronized (this.lockObject) {
-      this.invokeStartTimeMs = this.gatherPerfMetricsSetting ? System.currentTimeMillis() : 0;
+      this.invokeStartTimeMs =
+          this.gatherPerfMetricsSetting ? System.currentTimeMillis() : 0;
 
       Object result = super.invoke(proxy, method, args);
 
@@ -1125,7 +1185,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     Object result = null;
     try {
-      result = this.pluginManager.execute(this.thisAsConnection.getClass(), methodName, () -> method.invoke(this.thisAsConnection, args));
+      result = this.pluginManager.execute(
+          this.thisAsConnection.getClass(),
+          methodName,
+          () -> method.invoke(this.thisAsConnection, args));
       result = proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);
     } catch (InvocationTargetException e) {
       dealWithInvocationException(e);
@@ -1139,7 +1202,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
   private void invalidInvocationOnClosedConnection() throws SQLException {
     if (this.autoReconnect && !this.closedExplicitly) {
-      this.currentHostIndex = NO_CONNECTION_INDEX; // Act as if this is the first connection but let it sync with the previous one.
+      this.currentHostIndex =
+          NO_CONNECTION_INDEX; // Act as if this is the first connection but let it sync with the previous one.
       this.isClosed = false;
       this.closedReason = null;
       pickNewConnection();
@@ -1156,7 +1220,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       }
 
       releasePluginManager();
-      throw SQLError.createSQLException(reason, MysqlErrorNumbers.SQL_STATE_CONNECTION_NOT_OPEN, null /* no access to a interceptor here... */);
+      throw SQLError.createSQLException(
+          reason,
+          MysqlErrorNumbers.SQL_STATE_CONNECTION_NOT_OPEN,
+          null /* no access to a interceptor here... */);
     }
   }
 
@@ -1178,13 +1245,19 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     dealWithOriginalException(e.getCause(), e);
   }
 
-  private void dealWithOriginalException(Throwable originalException, Exception wrapperException) throws Throwable {
+  private void dealWithOriginalException(
+      Throwable originalException,
+      Exception wrapperException) throws Throwable {
     if (originalException != null) {
-      this.log.logTrace(Messages.getString("ClusterAwareConnectionProxy.12"), originalException);
-      if (this.lastExceptionDealtWith != originalException && shouldExceptionTriggerConnectionSwitch(originalException)) {
+      this.log.logTrace(
+          Messages.getString("ClusterAwareConnectionProxy.12"),
+          originalException);
+      if (this.lastExceptionDealtWith != originalException
+          && shouldExceptionTriggerConnectionSwitch(originalException)) {
         if (this.gatherPerfMetricsSetting) {
           long currentTimeMs = System.currentTimeMillis();
-          this.metrics.registerFailureDetectionTime(currentTimeMs - this.invokeStartTimeMs);
+          this.metrics.registerFailureDetectionTime(
+              currentTimeMs - this.invokeStartTimeMs);
           this.invokeStartTimeMs = 0;
           this.failoverStartTimeMs = currentTimeMs;
         }
@@ -1249,7 +1322,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     super.invalidateConnection(this.currentConnection);
   }
 
-  private void performSpecialMethodHandlingIfRequired(Object[] args, String methodName) throws SQLException {
+  private void performSpecialMethodHandlingIfRequired(Object[] args, String methodName)
+      throws SQLException {
     if (METHOD_SET_AUTO_COMMIT.equals(methodName)) {
       this.explicitlyAutoCommit = (Boolean) args[0];
       this.inTransaction = !this.explicitlyAutoCommit;
@@ -1296,9 +1370,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.close();
           return null;
         });
-      } catch(SQLException sqlEx) {
+      } catch (SQLException sqlEx) {
         throw sqlEx;
-      } catch(Exception ex) {
+      } catch (Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();
@@ -1318,9 +1392,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.abort(executor);
           return null;
         });
-      } catch(SQLException sqlEx) {
+      } catch (SQLException sqlEx) {
         throw sqlEx;
-      } catch(Exception ex) {
+      } catch (Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();
@@ -1340,9 +1414,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           this.currentConnection.abortInternal();
           return null;
         });
-      } catch(SQLException sqlEx) {
+      } catch (SQLException sqlEx) {
         throw sqlEx;
-      } catch(Exception ex) {
+      } catch (Exception ex) {
         throw new SQLException(ex.getMessage(), ex);
       }
       releasePluginManager();
@@ -1405,7 +1479,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           .append(hostInfo == null ? "<null>" : hostInfo.getHost());
     }
     this.log.logTrace(
-        Messages.getString("ClusterAwareConnectionProxy.11", new Object[] {msg.toString()}));
+        Messages.getString(
+            "ClusterAwareConnectionProxy.11",
+            new Object[] {msg.toString()}));
   }
 
   private void releasePluginManager() {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
@@ -79,8 +79,17 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
   protected final TopologyService topologyService;
 
   public ClusterAwareReaderFailoverHandler(
-          TopologyService topologyService, ConnectionProvider connProvider, Map<String, String> initialConnectionProps, Log log) {
-    this(topologyService, connProvider, initialConnectionProps, DEFAULT_FAILOVER_TIMEOUT, DEFAULT_READER_CONNECT_TIMEOUT, log);
+      TopologyService topologyService,
+      ConnectionProvider connProvider,
+      Map<String, String> initialConnectionProps,
+      Log log) {
+    this(
+        topologyService,
+        connProvider,
+        initialConnectionProps,
+        DEFAULT_FAILOVER_TIMEOUT,
+        DEFAULT_READER_CONNECT_TIMEOUT,
+        log);
   }
 
 
@@ -88,7 +97,12 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
    * ClusterAwareReaderFailoverHandler constructor.
    * */
   public ClusterAwareReaderFailoverHandler(
-      TopologyService topologyService, ConnectionProvider connProvider, Map<String, String> initialConnectionProps, int failoverTimeoutMs, int timeoutMs, Log log) {
+      TopologyService topologyService,
+      ConnectionProvider connProvider,
+      Map<String, String> initialConnectionProps,
+      int failoverTimeoutMs,
+      int timeoutMs,
+      Log log) {
     this.topologyService = topologyService;
     this.connProvider = connProvider;
     this.initialConnectionProps = initialConnectionProps;
@@ -122,17 +136,24 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
   @Override
   public ReaderFailoverResult failover(List<HostInfo> hosts, HostInfo currentHost)
       throws SQLException {
-    if(Util.isNullOrEmpty(hosts)) {
-      this.log.logDebug(Messages.getString("ClusterAwareReaderFailover.6", new Object[] { "failover" }));
-      return new ReaderFailoverResult(null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+    if (Util.isNullOrEmpty(hosts)) {
+      this.log.logDebug(Messages.getString("ClusterAwareReaderFailover.6", new Object[] {"failover"}));
+      return new ReaderFailoverResult(
+          null,
+          ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+          false);
     }
 
     ExecutorService executor = Executors.newSingleThreadExecutor();
-    Future<ReaderFailoverResult> future = submitInternalFailoverTask(hosts, currentHost, executor);
+    Future<ReaderFailoverResult> future =
+        submitInternalFailoverTask(hosts, currentHost, executor);
     return getInternalFailoverResult(executor, future);
   }
 
-  private Future<ReaderFailoverResult> submitInternalFailoverTask(List<HostInfo> hosts, HostInfo currentHost, ExecutorService executor) {
+  private Future<ReaderFailoverResult> submitInternalFailoverTask(
+      List<HostInfo> hosts,
+      HostInfo currentHost,
+      ExecutorService executor) {
     Future<ReaderFailoverResult> future = executor.submit(() -> {
       ReaderFailoverResult result = null;
       while (result == null || !result.isConnected()) {
@@ -145,17 +166,20 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     return future;
   }
 
-  private ReaderFailoverResult getInternalFailoverResult(ExecutorService executor, Future<ReaderFailoverResult> future) throws SQLException {
+  private ReaderFailoverResult getInternalFailoverResult(
+      ExecutorService executor,
+      Future<ReaderFailoverResult> future) throws SQLException {
     ReaderFailoverResult defaultResult = new ReaderFailoverResult(
-            null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+        null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
     try {
-      ReaderFailoverResult result = future.get(this.maxFailoverTimeoutMs, TimeUnit.MILLISECONDS);
+      ReaderFailoverResult result =
+          future.get(this.maxFailoverTimeoutMs, TimeUnit.MILLISECONDS);
       return result == null ? defaultResult : result;
 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new SQLException(
-              Messages.getString("ClusterAwareReaderFailoverHandler.1"), "70100", e);
+          Messages.getString("ClusterAwareReaderFailoverHandler.1"), "70100", e);
 
     } catch (ExecutionException e) {
       return defaultResult;
@@ -171,8 +195,10 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     }
   }
 
-  protected ReaderFailoverResult failoverInternal(List<HostInfo> hosts, HostInfo currentHost)
-          throws SQLException {
+  protected ReaderFailoverResult failoverInternal(
+      List<HostInfo> hosts,
+      HostInfo currentHost)
+      throws SQLException {
     this.topologyService.addToDownHostList(currentHost);
     Set<String> downHosts = topologyService.getDownHosts();
     List<HostTuple> hostGroup = getHostTuplesByPriority(hosts, downHosts);
@@ -184,16 +210,20 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     addActiveReaders(hostGroup, hosts, downHosts);
     HostInfo writerHost = hosts.get(ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX);
     hostGroup.add(
-            new HostTuple(
-                    writerHost,
-                    ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX));
+        new HostTuple(
+            writerHost,
+            ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX));
     addDownHosts(hostGroup, hosts, downHosts);
     return hostGroup;
   }
 
-  private void addActiveReaders(List<HostTuple> list, List<HostInfo> hosts, Set<String> downHosts) {
+  private void addActiveReaders(
+      List<HostTuple> list,
+      List<HostInfo> hosts,
+      Set<String> downHosts) {
     List<HostTuple> activeReaders = new ArrayList<>();
-    for (int i = ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX + 1; i < hosts.size(); i++) {
+    for (int i = ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX + 1;
+         i < hosts.size(); i++) {
       HostInfo host = hosts.get(i);
       if (!downHosts.contains(host.getHostPortPair())) {
         activeReaders.add(new HostTuple(host, i));
@@ -203,7 +233,10 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     list.addAll(activeReaders);
   }
 
-  private void addDownHosts(List<HostTuple> list, List<HostInfo> hosts, Set<String> downHosts) {
+  private void addDownHosts(
+      List<HostTuple> list,
+      List<HostInfo> hosts,
+      Set<String> downHosts) {
     List<HostTuple> downHostList = new ArrayList<>();
     for (int i = 0; i < hosts.size(); i++) {
       HostInfo host = hosts.get(i);
@@ -223,10 +256,14 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
    * @return {@link ReaderFailoverResult} The results of this process.
    */
   @Override
-  public ReaderFailoverResult getReaderConnection(List<HostInfo> hostList) throws SQLException {
-    if(Util.isNullOrEmpty(hostList)) {
-      this.log.logDebug(Messages.getString("ClusterAwareReaderFailover.6", new Object[] { "getReaderConnection" }));
-      return new ReaderFailoverResult(null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+  public ReaderFailoverResult getReaderConnection(List<HostInfo> hostList)
+      throws SQLException {
+    if (Util.isNullOrEmpty(hostList)) {
+      this.log.logDebug(Messages.getString("ClusterAwareReaderFailover.6", new Object[] {"getReaderConnection"}));
+      return new ReaderFailoverResult(
+          null,
+          ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+          false);
     }
 
     Set<String> downHosts = topologyService.getDownHosts();
@@ -234,14 +271,19 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     return getConnectionFromHostGroup(tuples);
   }
 
-  List<HostTuple> getReaderTuplesByPriority(List<HostInfo> hostList, Set<String> downHosts) {
+  List<HostTuple> getReaderTuplesByPriority(
+      List<HostInfo> hostList,
+      Set<String> downHosts) {
     List<HostTuple> tuples = new ArrayList<>();
     addActiveReaders(tuples, hostList, downHosts);
     addDownReaders(tuples, hostList, downHosts);
     return tuples;
   }
 
-  private void addDownReaders(List<HostTuple> list, List<HostInfo> hosts, Set<String> downHosts) {
+  private void addDownReaders(
+      List<HostTuple> list,
+      List<HostInfo> hosts,
+      Set<String> downHosts) {
     List<HostTuple> downReaders = new ArrayList<>();
     for (int i = ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX + 1; i < hosts.size(); i++) {
       HostInfo host = hosts.get(i);
@@ -262,7 +304,8 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     try {
       for (int i = 0; i < hostGroup.size(); i += 2) {
         // submit connection attempt tasks in batches of 2
-        ReaderFailoverResult result = getResultFromNextTaskBatch(hostGroup, executor, completionService, i);
+        ReaderFailoverResult result =
+            getResultFromNextTaskBatch(hostGroup, executor, completionService, i);
         if (result.isConnected()) {
           return result;
         }
@@ -272,42 +315,54 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new SQLException(
-                  Messages.getString("ClusterAwareReaderFailoverHandler.1"), "70100", e);
+              Messages.getString("ClusterAwareReaderFailoverHandler.1"), "70100", e);
         }
       }
 
-      return new ReaderFailoverResult(null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+      return new ReaderFailoverResult(
+          null,
+          ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+          false);
     } finally {
       executor.shutdownNow();
     }
   }
 
-  private ReaderFailoverResult getResultFromNextTaskBatch(List<HostTuple> hostGroup, ExecutorService executor, CompletionService<ReaderFailoverResult> completionService, int i) throws SQLException {
+  private ReaderFailoverResult getResultFromNextTaskBatch(
+      List<HostTuple> hostGroup,
+      ExecutorService executor,
+      CompletionService<ReaderFailoverResult> completionService,
+      int i) throws SQLException {
     ReaderFailoverResult result;
     int numTasks = i + 1 < hostGroup.size() ? 2 : 1;
     completionService.submit(new ConnectionAttemptTask(hostGroup.get(i)));
     if (numTasks == 2) {
       completionService.submit(new ConnectionAttemptTask(hostGroup.get(i + 1)));
     }
-    for(int taskNum = 0; taskNum < numTasks; taskNum++) {
+    for (int taskNum = 0; taskNum < numTasks; taskNum++) {
       result = getNextResult(completionService);
       if (result.isConnected()) {
         executor.shutdownNow();
         this.log.logDebug(
-                Messages.getString(
-                        "ClusterAwareReaderFailoverHandler.2", new Object[]{result.getConnectionIndex()}));
+            Messages.getString(
+                "ClusterAwareReaderFailoverHandler.2",
+                new Object[] {result.getConnectionIndex()}));
         return result;
       }
     }
-    return new ReaderFailoverResult(null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+    return new ReaderFailoverResult(
+        null,
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        false);
   }
 
   private ReaderFailoverResult getNextResult(CompletionService<ReaderFailoverResult> service)
       throws SQLException {
     ReaderFailoverResult defaultResult = new ReaderFailoverResult(
-            null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+        null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
     try {
-      Future<ReaderFailoverResult> future = service.poll(this.timeoutMs, TimeUnit.MILLISECONDS);
+      Future<ReaderFailoverResult> future =
+          service.poll(this.timeoutMs, TimeUnit.MILLISECONDS);
       if (future == null) {
         return defaultResult;
       }
@@ -318,7 +373,10 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       // "Thread was interrupted"
-      throw new SQLException(Messages.getString("ClusterAwareReaderFailoverHandler.1"), "70100", e);
+      throw new SQLException(
+          Messages.getString("ClusterAwareReaderFailoverHandler.1"),
+          "70100",
+          e);
     }
   }
 
@@ -341,7 +399,8 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
               new Object[] {this.newHostTuple.getIndex(), newHost.getHostPortPair()}));
 
       try {
-        HostInfo newHostWithProps = ClusterAwareUtils.copyWithAdditionalProps(newHost, initialConnectionProps);
+        HostInfo newHostWithProps =
+            ClusterAwareUtils.copyWithAdditionalProps(newHost, initialConnectionProps);
         JdbcConnection conn = connProvider.connect(newHostWithProps);
         topologyService.removeFromDownHostList(newHost);
         log.logDebug(
@@ -355,7 +414,10 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
             Messages.getString(
                 "ClusterAwareReaderFailoverHandler.5",
                 new Object[] {this.newHostTuple.getIndex(), newHost.getHostPortPair()}));
-        return new ReaderFailoverResult(null, ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, false);
+        return new ReaderFailoverResult(
+            null,
+            ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+            false);
       }
     }
   }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
@@ -39,58 +39,72 @@ import java.util.Map;
 import java.util.Properties;
 
 public class ClusterAwareUtils {
-    /**
-     * Create a copy of the given {@link HostInfo} object where all details are the same except for the host properties,
-     * which will contain both the original properties and the properties passed into the function
-     *
-     * @param baseHostInfo The {@link HostInfo} object to copy
-     * @param additionalProps The map of properties to add to the new {@link HostInfo} copy
-     *
-     * @return A copy of the given {@link HostInfo} object where all details are the same except for the host properties,
-     *      will contain both the original properties and the properties passed into the function. Returns null if
-     *      baseHostInfo is null
-     */
-    public static HostInfo copyWithAdditionalProps(HostInfo baseHostInfo, Map<String, String> additionalProps) {
-        if (baseHostInfo == null || additionalProps == null) {
-            return baseHostInfo;
-        }
-
-        DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(baseHostInfo.getDatabaseUrl(), new Properties());
-        Map<String, String> originalProps = baseHostInfo.getHostProperties();
-        Map<String, String> mergedProps = new HashMap<>();
-        mergedProps.putAll(originalProps);
-        mergedProps.putAll(additionalProps);
-        return new HostInfo(urlContainer, baseHostInfo.getHost(), baseHostInfo.getPort(), baseHostInfo.getUser(), baseHostInfo.getPassword(), mergedProps);
+  /**
+   * Create a copy of the given {@link HostInfo} object where all details are the same except for the host properties,
+   * which will contain both the original properties and the properties passed into the function.
+   *
+   * @param baseHostInfo The {@link HostInfo} object to copy
+   * @param additionalProps The map of properties to add to the new {@link HostInfo} copy
+   *
+   * @return A copy of the given {@link HostInfo} object where all details are the same except for the host properties,
+   *      will contain both the original properties and the properties passed into the function. Returns null if
+   *      baseHostInfo is null
+   */
+  public static HostInfo copyWithAdditionalProps(
+      HostInfo baseHostInfo,
+      Map<String, String> additionalProps) {
+    if (baseHostInfo == null || additionalProps == null) {
+      return baseHostInfo;
     }
 
-    /**
-     * Create a copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object
-     *
-     * @param baseHostInfo The {@link HostInfo} object to copy host and port from
-     * @param connectionUrl All other properties to add to the new {@link HostInfo}
-     *
-     * @return A copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object
-     *      Returns baseHostInfo if connectionUrl is null
-     *      Returns connectionUrl's HostInfo if baseHostInfo is null
-     */
-    public static HostInfo copyWithAdditionalProps(HostInfo baseHostInfo, ConnectionUrl connectionUrl) {
-        if (connectionUrl == null) {
-            return baseHostInfo;
-        }
+    DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(
+        baseHostInfo.getDatabaseUrl(),
+        new Properties());
+    Map<String, String> originalProps = baseHostInfo.getHostProperties();
+    Map<String, String> mergedProps = new HashMap<>();
+    mergedProps.putAll(originalProps);
+    mergedProps.putAll(additionalProps);
+    return new HostInfo(
+        urlContainer,
+        baseHostInfo.getHost(),
+        baseHostInfo.getPort(),
+        baseHostInfo.getUser(),
+        baseHostInfo.getPassword(),
+        mergedProps);
+  }
 
-        final HostInfo mainHost = connectionUrl.getMainHost();
-        if (baseHostInfo == null) {
-            return mainHost;
-        }
-
-        DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(baseHostInfo.getDatabaseUrl(), new Properties());
-        Map<String, String> originalProps = baseHostInfo.getHostProperties();
-        Map<String, String> mergedProps = new HashMap<>();
-        mergedProps.putAll(originalProps);
-        mergedProps.putAll(mainHost.getHostProperties());
-
-        return new HostInfo(urlContainer, baseHostInfo.getHost(), baseHostInfo.getPort(),
-            mainHost.getUser(), mainHost.getPassword(),
-            mergedProps);
+  /**
+   * Create a copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object.
+   *
+   * @param baseHostInfo The {@link HostInfo} object to copy host and port from
+   * @param connectionUrl All other properties to add to the new {@link HostInfo}
+   *
+   * @return A copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object
+   *      Returns baseHostInfo if connectionUrl is null
+   *      Returns connectionUrl's HostInfo if baseHostInfo is null
+   */
+  public static HostInfo copyWithAdditionalProps(
+      HostInfo baseHostInfo,
+      ConnectionUrl connectionUrl) {
+    if (connectionUrl == null) {
+      return baseHostInfo;
     }
+
+    final HostInfo mainHost = connectionUrl.getMainHost();
+    if (baseHostInfo == null) {
+      return mainHost;
+    }
+
+    DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(
+        baseHostInfo.getDatabaseUrl(),
+        new Properties());
+    Map<String, String> originalProps = baseHostInfo.getHostProperties();
+    Map<String, String> mergedProps = new HashMap<>();
+    mergedProps.putAll(originalProps);
+    mergedProps.putAll(mainHost.getHostProperties());
+
+    return new HostInfo(urlContainer, baseHostInfo.getHost(), baseHostInfo.getPort(),
+        mainHost.getUser(), mainHost.getPassword(),
+        mergedProps);
+  }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandler.java
@@ -107,7 +107,12 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
       int readTopologyIntervalMs,
       int reconnectWriterIntervalMs,
       Log log) {
-    this(topologyService, connectionProvider, readerFailoverHandler, initialConnectionProps, log);
+    this(
+        topologyService,
+        connectionProvider,
+        readerFailoverHandler,
+        initialConnectionProps,
+        log);
     this.maxFailoverTimeoutMs = failoverTimeoutMs;
     this.readTopologyIntervalMs = readTopologyIntervalMs;
     this.reconnectWriterIntervalMs = reconnectWriterIntervalMs;
@@ -120,22 +125,27 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
    * @return {@link WriterFailoverResult} The results of this process.
    */
   @Override
-  public WriterFailoverResult failover(List<HostInfo> currentTopology) throws SQLException {
-    if(Util.isNullOrEmpty(currentTopology)) {
+  public WriterFailoverResult failover(List<HostInfo> currentTopology)
+      throws SQLException {
+    if (Util.isNullOrEmpty(currentTopology)) {
       this.log.logError(Messages.getString("ClusterAwareWriterFailoverHandler.7"));
       return new WriterFailoverResult(false, false, null, null, "None");
     }
 
     ExecutorService executorService = Executors.newFixedThreadPool(2);
     CompletionService<WriterFailoverResult> completionService =
-            new ExecutorCompletionService<>(executorService);
+        new ExecutorCompletionService<>(executorService);
     submitTasks(currentTopology, executorService, completionService);
 
     try {
       WriterFailoverResult result = getNextResult(executorService, completionService);
-      if (result.isConnected()) return result;
+      if (result.isConnected()) {
+        return result;
+      }
       result = getNextResult(executorService, completionService);
-      if (result.isConnected()) return result;
+      if (result.isConnected()) {
+        return result;
+      }
 
       this.log.logDebug(Messages.getString("ClusterAwareWriterFailoverHandler.3"));
       return new WriterFailoverResult(false, false, null, null, "None");
@@ -146,27 +156,33 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     }
   }
 
-  private void submitTasks(List<HostInfo> currentTopology, ExecutorService executorService,
-                          CompletionService<WriterFailoverResult> completionService) {
+  private void submitTasks(
+      List<HostInfo> currentTopology, ExecutorService executorService,
+      CompletionService<WriterFailoverResult> completionService) {
     HostInfo writerHost = currentTopology.get(WRITER_CONNECTION_INDEX);
-    HostInfo writerHostWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(writerHost, this.initialConnectionProps);
+    HostInfo writerHostWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(
+        writerHost,
+        this.initialConnectionProps);
     this.topologyService.addToDownHostList(writerHost);
     completionService.submit(new ReconnectToWriterHandler(writerHostWithInitialProps));
-    completionService.submit(new WaitForNewWriterHandler(currentTopology, writerHostWithInitialProps));
+    completionService.submit(new WaitForNewWriterHandler(
+        currentTopology,
+        writerHostWithInitialProps));
     executorService.shutdown();
   }
 
-  private WriterFailoverResult getNextResult(ExecutorService executorService,
-      CompletionService<WriterFailoverResult> completionService) throws SQLException{
+  private WriterFailoverResult getNextResult(
+      ExecutorService executorService,
+      CompletionService<WriterFailoverResult> completionService) throws SQLException {
     try {
       Future<WriterFailoverResult> firstCompleted = completionService.poll(
-              this.maxFailoverTimeoutMs, TimeUnit.MILLISECONDS);
-      if(firstCompleted == null) {
+          this.maxFailoverTimeoutMs, TimeUnit.MILLISECONDS);
+      if (firstCompleted == null) {
         // The task was unsuccessful and we have timed out
         return new WriterFailoverResult(false, false, new ArrayList<>(), null, "None");
       }
       WriterFailoverResult result = firstCompleted.get();
-      if(result.isConnected()) {
+      if (result.isConnected()) {
         executorService.shutdownNow();
         logTaskSuccess(result);
         return result;
@@ -182,23 +198,32 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
 
   private void logTaskSuccess(WriterFailoverResult result) {
     List<HostInfo> topology = result.getTopology();
-    if(Util.isNullOrEmpty(topology)) {
+    if (Util.isNullOrEmpty(topology)) {
       String taskName = result.getTaskName() == null ? "None" : result.getTaskName();
-      this.log.logError(Messages.getString("ClusterAwareWriterFailoverHandler.5", new Object[] { taskName }));
+      this.log.logError(Messages.getString(
+          "ClusterAwareWriterFailoverHandler.5",
+          new Object[] {taskName}));
       return;
     }
 
     String newWriterHost = topology.get(WRITER_CONNECTION_INDEX).getHostPortPair();
-    if(result.isNewHost()) {
-      this.log.logDebug(Messages.getString("ClusterAwareWriterFailoverHandler.4", new Object[] { newWriterHost }));
-    } else  {
-      this.log.logDebug(Messages.getString("ClusterAwareWriterFailoverHandler.2", new Object[] { newWriterHost }));
+    if (result.isNewHost()) {
+      this.log.logDebug(Messages.getString(
+          "ClusterAwareWriterFailoverHandler.4",
+          new Object[] {newWriterHost}));
+    } else {
+      this.log.logDebug(Messages.getString(
+          "ClusterAwareWriterFailoverHandler.2",
+          new Object[] {newWriterHost}));
     }
   }
 
   private SQLException createInterruptedException(InterruptedException e) {
     // "Thread was interrupted"
-    return new SQLException(Messages.getString("ClusterAwareWriterFailoverHandler.1"), "70100", e);
+    return new SQLException(
+        Messages.getString("ClusterAwareWriterFailoverHandler.1"),
+        "70100",
+        e);
   }
 
   /** Internal class responsible for re-connecting to the current writer (aka TaskA). */
@@ -211,16 +236,17 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
 
     public WriterFailoverResult call() {
       log.logDebug(
-              Messages.getString(
-                      "ClusterAwareWriterFailoverHandler.6",
-                      new Object[] {this.originalWriterHost.getHostPortPair()}));
+          Messages.getString(
+              "ClusterAwareWriterFailoverHandler.6",
+              new Object[] {this.originalWriterHost.getHostPortPair()}));
       try {
         while (true) {
           try {
             JdbcConnection conn = connectionProvider.connect(this.originalWriterHost);
 
             List<HostInfo> latestTopology = topologyService.getTopology(conn, true);
-            if (!Util.isNullOrEmpty(latestTopology) && isCurrentHostWriter(latestTopology)) {
+            if (!Util.isNullOrEmpty(latestTopology)
+                && isCurrentHostWriter(latestTopology)) {
               topologyService.removeFromDownHostList(this.originalWriterHost);
               return new WriterFailoverResult(true, false, latestTopology, conn, "TaskA");
             }
@@ -243,7 +269,9 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
 
     private boolean isCurrentHostWriter(List<HostInfo> latestTopology) {
       String currentInstanceName =
-          this.originalWriterHost.getHostProperties().get(TopologyServicePropertyKeys.INSTANCE_NAME);
+          this.originalWriterHost
+              .getHostProperties()
+              .get(TopologyServicePropertyKeys.INSTANCE_NAME);
       HostInfo latestWriter = latestTopology.get(WRITER_CONNECTION_INDEX);
       if (currentInstanceName == null) {
         return false;
@@ -280,16 +308,23 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
         while (!success) {
           connectToReader();
           success = refreshTopologyAndConnectToNewWriter();
-          if(!success) {
+          if (!success) {
             closeReaderConnection();
           }
         }
-        return new WriterFailoverResult(true, true, this.currentTopology, this.currentConnection, "TaskB");
+        return new WriterFailoverResult(
+            true,
+            true,
+            this.currentTopology,
+            this.currentConnection,
+            "TaskB");
       } catch (InterruptedException exception) {
         Thread.currentThread().interrupt();
         return new WriterFailoverResult(false, false, null, null, "TaskB");
       } catch (Exception ex) {
-        log.logError(Messages.getString("ClusterAwareWriterFailoverHandler.15", new Object[] { ex.getMessage() }));
+        log.logError(Messages.getString(
+            "ClusterAwareWriterFailoverHandler.15",
+            new Object[] {ex.getMessage()}));
         throw ex;
       } finally {
         performFinalCleanup();
@@ -300,14 +335,16 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
       while (true) {
         try {
           ReaderFailoverResult connResult =
-                  readerFailoverHandler.getReaderConnection(this.currentTopology);
-          if(isValidReaderConnection(connResult)) {
+              readerFailoverHandler.getReaderConnection(this.currentTopology);
+          if (isValidReaderConnection(connResult)) {
             this.currentReaderConnection = connResult.getConnection();
-            this.currentReaderHost = this.currentTopology.get(connResult.getConnectionIndex());
+            this.currentReaderHost =
+                this.currentTopology.get(connResult.getConnectionIndex());
             log.logDebug(
-                    Messages.getString(
-                            "ClusterAwareWriterFailoverHandler.11",
-                            new Object[]{connResult.getConnectionIndex(), this.currentReaderHost.getHostPortPair()}));
+                Messages.getString(
+                    "ClusterAwareWriterFailoverHandler.11",
+                    new Object[] {connResult.getConnectionIndex(),
+                        this.currentReaderHost.getHostPortPair()}));
             break;
           }
         } catch (SQLException e) {
@@ -319,13 +356,13 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     }
 
     private boolean isValidReaderConnection(ReaderFailoverResult result) {
-      if(!result.isConnected() || result.getConnection() == null) {
+      if (!result.isConnected() || result.getConnection() == null) {
         return false;
       }
       int connIndex = result.getConnectionIndex();
       return connIndex != ClusterAwareConnectionProxy.NO_CONNECTION_INDEX
-              && connIndex < this.currentTopology.size()
-              && this.currentTopology.get(connIndex) != null;
+          && connIndex < this.currentTopology.size()
+          && this.currentTopology.get(connIndex) != null;
     }
 
     /**
@@ -335,7 +372,8 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
      */
     private boolean refreshTopologyAndConnectToNewWriter() throws InterruptedException {
       while (true) {
-        List<HostInfo> topology = topologyService.getTopology(this.currentReaderConnection, true);
+        List<HostInfo> topology =
+            topologyService.getTopology(this.currentReaderConnection, true);
         if (!topology.isEmpty()) {
           this.currentTopology = topology;
           HostInfo writerCandidate = this.currentTopology.get(WRITER_CONNECTION_INDEX);
@@ -361,22 +399,26 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
       return writerCandidate
           .getHostProperties()
           .get(TopologyServicePropertyKeys.INSTANCE_NAME)
-          .equals(originalWriter.getHostProperties().get(TopologyServicePropertyKeys.INSTANCE_NAME));
+          .equals(originalWriter
+              .getHostProperties()
+              .get(TopologyServicePropertyKeys.INSTANCE_NAME));
     }
 
     private boolean connectToWriter(HostInfo writerCandidate) {
       try {
         log.logDebug(
-                Messages.getString(
-                        "ClusterAwareWriterFailoverHandler.14",
-                        new Object[] {writerCandidate.getHostPortPair()}));
+            Messages.getString(
+                "ClusterAwareWriterFailoverHandler.14",
+                new Object[] {writerCandidate.getHostPortPair()}));
 
         if (isSame(writerCandidate, this.currentReaderHost)) {
           this.currentConnection = this.currentReaderConnection;
         } else {
           // connect to the new writer
           HostInfo writerCandidateWithProps =
-                  ClusterAwareUtils.copyWithAdditionalProps(writerCandidate, initialConnectionProps);
+              ClusterAwareUtils.copyWithAdditionalProps(
+                  writerCandidate,
+                  initialConnectionProps);
           this.currentConnection = connectionProvider.connect(writerCandidateWithProps);
         }
 
@@ -389,11 +431,12 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     }
 
     /**
-     * Close the reader connection if not done so already, and mark the relevant fields as null
+     * Close the reader connection if not done so already, and mark the relevant fields as null.
      */
     private void closeReaderConnection() {
       try {
-        if (this.currentReaderConnection != null && !this.currentReaderConnection.isClosed()) {
+        if (this.currentReaderConnection != null
+            && !this.currentReaderConnection.isClosed()) {
           this.currentReaderConnection.close();
         }
       } catch (SQLException e) {
@@ -405,7 +448,8 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
 
     private void performFinalCleanup() {
       // Close the reader connection if it's not needed.
-      if (this.currentReaderConnection != null && this.currentConnection != this.currentReaderConnection) {
+      if (this.currentReaderConnection != null
+          && this.currentConnection != this.currentReaderConnection) {
         try {
           this.currentReaderConnection.close();
         } catch (SQLException e) {
@@ -426,7 +470,7 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
       }
       log.logTrace(
           Messages.getString(
-                  "ClusterAwareWriterFailoverHandler.13", new Object[] {msg.toString()}));
+              "ClusterAwareWriterFailoverHandler.13", new Object[] {msg.toString()}));
     }
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -71,8 +71,8 @@ public class ConnectionPluginManager {
    * If {@code PropertyKey.connectionPluginFactories} is provided by the user, initialize
    * the chain with the given connection plugins in the order they are specified. Otherwise,
    * initialize the {@link NodeMonitoringConnectionPlugin} instead.
-   * <p>
-   * The {@link DefaultConnectionPlugin} will always be initialized and attached as the
+   *
+   * <p>The {@link DefaultConnectionPlugin} will always be initialized and attached as the
    * last connection plugin in the chain.
    *
    * @param proxy The connection the plugins are associated with.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -37,6 +37,9 @@ import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+/**
+ * This class creates and handles a chain of {@link IConnectionPlugin} for each connection.
+ */
 public class ConnectionPluginManager {
 
   /* THIS CLASS IS NOT MULTI-THREADING SAFE */
@@ -63,6 +66,18 @@ public class ConnectionPluginManager {
     this.logger = logger;
   }
 
+  /**
+   * Initialize a chain of {@link IConnectionPlugin} using their corresponding {@link IConnectionPluginFactory}.
+   * If {@code PropertyKey.connectionPluginFactories} is provided by the user, initialize
+   * the chain with the given connection plugins in the order they are specified. Otherwise,
+   * initialize the {@link NodeMonitoringConnectionPlugin} instead.
+   * <p>
+   * The {@link DefaultConnectionPlugin} will always be initialized and attached as the
+   * last connection plugin in the chain.
+   *
+   * @param proxy The connection the plugins are associated with.
+   * @param propertySet The configuration of the connection.
+   */
   public void init(ClusterAwareConnectionProxy proxy, PropertySet propertySet) {
     instances.add(this);
     this.proxy = proxy;
@@ -105,7 +120,10 @@ public class ConnectionPluginManager {
 
   }
 
-  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
+  public Object execute(
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<?> executeSqlFunc) throws Exception {
     return this.headPlugin.execute(methodInvokeOn, methodName, executeSqlFunc);
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -1,3 +1,29 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.log.Log;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPluginFactory.java
@@ -1,3 +1,29 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.conf.PropertySet;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
@@ -29,6 +29,8 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import java.util.concurrent.Callable;
 
 public interface IConnectionPlugin {
-  Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception;
+  Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc)
+      throws Exception;
+
   void releaseResources();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPluginFactory.java
@@ -1,3 +1,29 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.conf.PropertySet;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitor.java
@@ -28,7 +28,10 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 public interface IMonitor extends Runnable {
   void startMonitoring(MonitorConnectionContext context);
+
   void stopMonitoring(MonitorConnectionContext context);
+
   void clearContexts();
+
   boolean isStopped();
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
@@ -45,6 +45,7 @@ public interface IMonitorService {
   /**
    * Stop monitoring for a connection represented by the given
    * {@link MonitorConnectionContext}. Removes the context from the {@link Monitor}.
+   *
    * @param context The {@link MonitorConnectionContext} representing a connection.
    */
   void stopMonitoring(MonitorConnectionContext context);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -122,7 +122,8 @@ public class Monitor implements IMonitor {
           final long currentTime = this.getCurrentTimeMillis();
           this.lastContextUsedTimestamp.set(currentTime);
 
-          final ConnectionStatus status = checkConnectionStatus(this.getConnectionCheckIntervalMillis());
+          final ConnectionStatus status =
+              checkConnectionStatus(this.getConnectionCheckIntervalMillis());
 
           for (MonitorConnectionContext monitorContext : this.contexts) {
             monitorContext.updateConnectionStatus(
@@ -131,9 +132,12 @@ public class Monitor implements IMonitor {
                 this.connectionCheckIntervalMillis);
           }
 
-          TimeUnit.MILLISECONDS.sleep(Math.max(0, this.getConnectionCheckIntervalMillis() - status.elapsedTime));
+          TimeUnit.MILLISECONDS.sleep(Math.max(
+              0,
+              this.getConnectionCheckIntervalMillis() - status.elapsedTime));
         } else {
-          if ((this.getCurrentTimeMillis() - this.lastContextUsedTimestamp.get()) >= this.monitorDisposalTime) {
+          if ((this.getCurrentTimeMillis() - this.lastContextUsedTimestamp.get())
+              >= this.monitorDisposalTime) {
             monitorService.notifyUnused(this);
             break;
           }
@@ -161,19 +165,24 @@ public class Monitor implements IMonitor {
         // open a new connection
         Map<String, String> monitoringConnProperties = new HashMap<>();
         Properties originalProperties = this.propertySet.exposeAsProperties();
-        if(originalProperties != null) {
+        if (originalProperties != null) {
           originalProperties.stringPropertyNames().stream()
-                  .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
-                  .forEach(p -> monitoringConnProperties.put(p.substring(MONITORING_PROPERTY_PREFIX.length()), originalProperties.getProperty(p)));
+              .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
+              .forEach(p -> monitoringConnProperties.put(
+                  p.substring(MONITORING_PROPERTY_PREFIX.length()),
+                  originalProperties.getProperty(p)));
         }
 
         start = this.getCurrentTimeMillis();
-        this.monitoringConn = this.connectionProvider.connect(copy(this.hostInfo, monitoringConnProperties));
+        this.monitoringConn = this.connectionProvider.connect(copy(
+            this.hostInfo,
+            monitoringConnProperties));
         return new ConnectionStatus(true, this.getCurrentTimeMillis() - start);
       }
 
       start = this.getCurrentTimeMillis();
-      boolean isValid = this.monitoringConn.isValid(shortestFailureDetectionIntervalMillis / 1000);
+      boolean isValid =
+          this.monitoringConn.isValid(shortestFailureDetectionIntervalMillis / 1000);
       return new ConnectionStatus(isValid, this.getCurrentTimeMillis() - start);
     } catch (SQLException sqlEx) {
       //this.logger.logTrace(String.format("[Monitor] Error checking connection status: %s", sqlEx.getMessage()));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
@@ -94,21 +94,33 @@ public class MonitorConnectionContext {
     this.invalidNodeStartTime = invalidNodeStartTimeMillis;
   }
 
-  void resetInvalidNodeStartTime() { this.invalidNodeStartTime = 0; }
+  void resetInvalidNodeStartTime() {
+    this.invalidNodeStartTime = 0;
+  }
 
-  boolean isInvalidNodeStartTimeDefined() { return this.invalidNodeStartTime > 0; }
+  boolean isInvalidNodeStartTimeDefined() {
+    return this.invalidNodeStartTime > 0;
+  }
 
-  public long getInvalidNodeStartTime() { return this.invalidNodeStartTime; }
+  public long getInvalidNodeStartTime() {
+    return this.invalidNodeStartTime;
+  }
 
   public boolean isNodeUnhealthy() {
     return this.nodeUnhealthy;
   }
 
-  void setNodeUnhealthy(boolean nodeUnhealthy) { this.nodeUnhealthy = nodeUnhealthy; }
+  void setNodeUnhealthy(boolean nodeUnhealthy) {
+    this.nodeUnhealthy = nodeUnhealthy;
+  }
 
-  public boolean isActiveContext() { return this.activeContext; }
+  public boolean isActiveContext() {
+    return this.activeContext;
+  }
 
-  public void invalidate() { this.activeContext = false; }
+  public void invalidate() {
+    this.activeContext = false;
+  }
 
   synchronized void abortConnection() {
     if (this.connectionToAbort == null || !this.activeContext) {
@@ -119,11 +131,16 @@ public class MonitorConnectionContext {
       this.connectionToAbort.abortInternal();
     } catch (SQLException sqlEx) {
       // ignore
-      this.log.logTrace(String.format("Exception during aborting connection: %s", sqlEx.getMessage()));
+      this.log.logTrace(String.format(
+          "Exception during aborting connection: %s",
+          sqlEx.getMessage()));
     }
   }
 
-  public void updateConnectionStatus(long currentTime, boolean isValid, long validationIntervalTimeMillis) {
+  public void updateConnectionStatus(
+      long currentTime,
+      boolean isValid,
+      long validationIntervalTimeMillis) {
     if (!this.activeContext) {
       return;
     }
@@ -135,7 +152,10 @@ public class MonitorConnectionContext {
     }
   }
 
-  void setConnectionValid(boolean connectionValid, long currentTime, long validationIntervalTimeMillis) {
+  void setConnectionValid(
+      boolean connectionValid,
+      long currentTime,
+      long validationIntervalTimeMillis) {
     if (!connectionValid) {
       this.failureCount++;
 
@@ -144,7 +164,9 @@ public class MonitorConnectionContext {
       }
 
       final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
-      final long maxInvalidNodeDurationMillis = (long) this.getFailureDetectionIntervalMillis() * this.getFailureDetectionCount();
+      final long maxInvalidNodeDurationMillis =
+          (long) this.getFailureDetectionIntervalMillis()
+              * this.getFailureDetectionCount();
 
       if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
         this.log.logTrace(
@@ -168,7 +190,8 @@ public class MonitorConnectionContext {
     this.setNodeUnhealthy(false);
 
     this.log.logTrace(
-        String.format("[MonitorConnectionContext] node '%s' is *alive*.",
+        String.format(
+            "[MonitorConnectionContext] node '%s' is *alive*.",
             nodeKeys));
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginFactory.java
@@ -1,3 +1,29 @@
+/*
+ * AWS JDBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.conf.PropertySet;

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
@@ -64,26 +64,29 @@ import static org.mockito.Mockito.when;
 
 /**
  * ClusterAwareReaderFailoverHandlerTest class.
- * */
+ */
 public class ClusterAwareReaderFailoverHandlerTest {
   static final List<HostInfo> testHosts;
+
   static {
     testHosts = new ArrayList<>();
     List<String> instances = Arrays.asList(
-            "writer-1",
-            "reader-1",
-            "reader-2",
-            "reader-3",
-            "reader-4",
-            "reader-5"
+        "writer-1",
+        "reader-1",
+        "reader-2",
+        "reader-3",
+        "reader-4",
+        "reader-5"
     );
-    for(String instance : instances) {
+
+    for (String instance : instances) {
       HostInfo host = ClusterAwareTestUtils.createBasicHostInfo(instance, "test");
       testHosts.add(host);
     }
   }
 
   static final Map<String, String> testConnectionProps;
+
   static {
     testConnectionProps = new HashMap<>();
     testConnectionProps.put(PropertyKey.DBNAME.getKeyName(), "test");
@@ -120,8 +123,13 @@ public class ClusterAwareReaderFailoverHandlerTest {
     when(mockTopologyService.getDownHosts()).thenReturn(downHosts);
 
     final ReaderFailoverHandler target =
-        new ClusterAwareReaderFailoverHandler(mockTopologyService, mockConnProvider, testConnectionProps, mockLog);
-    final ReaderFailoverResult result = target.failover(hosts, hosts.get(currentHostIndex));
+        new ClusterAwareReaderFailoverHandler(
+            mockTopologyService,
+            mockConnProvider,
+            testConnectionProps,
+            mockLog);
+    final ReaderFailoverResult result =
+        target.failover(hosts, hosts.get(currentHostIndex));
 
     assertTrue(result.isConnected());
     assertSame(mockConnection, result.getConnection());
@@ -158,10 +166,10 @@ public class ClusterAwareReaderFailoverHandlerTest {
     final int currentHostIndex = 2;
     for (HostInfo host : hosts) {
       when(mockConnProvider.connect(refEq(host)))
-              .thenAnswer((Answer<ConnectionImpl>) invocation -> {
-                Thread.sleep(20000);
-                return mockConnection;
-              });
+          .thenAnswer((Answer<ConnectionImpl>) invocation -> {
+            Thread.sleep(20000);
+            return mockConnection;
+          });
     }
 
     final Set<String> downHosts = new HashSet<>();
@@ -172,12 +180,21 @@ public class ClusterAwareReaderFailoverHandlerTest {
     when(mockTopologyService.getDownHosts()).thenReturn(downHosts);
 
     final ReaderFailoverHandler target =
-            new ClusterAwareReaderFailoverHandler(mockTopologyService, mockConnProvider, testConnectionProps, 5000, 30000, mockLog);
-    final ReaderFailoverResult result = target.failover(hosts, hosts.get(currentHostIndex));
+        new ClusterAwareReaderFailoverHandler(
+            mockTopologyService,
+            mockConnProvider,
+            testConnectionProps,
+            5000,
+            30000,
+            mockLog);
+    final ReaderFailoverResult result =
+        target.failover(hosts, hosts.get(currentHostIndex));
 
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
-    assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
+    assertEquals(
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        result.getConnectionIndex());
   }
 
   @Test
@@ -185,19 +202,26 @@ public class ClusterAwareReaderFailoverHandlerTest {
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
     final ClusterAwareReaderFailoverHandler target =
         new ClusterAwareReaderFailoverHandler(
-            mockTopologyService, Mockito.mock(ConnectionProvider.class), testConnectionProps, mockLog);
+            mockTopologyService,
+            Mockito.mock(ConnectionProvider.class),
+            testConnectionProps,
+            mockLog);
     final HostInfo currentHost = new HostInfo(null, "writer", 1234, null, null);
 
     ReaderFailoverResult result = target.failover(null, currentHost);
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
-    assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
+    assertEquals(
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        result.getConnectionIndex());
 
     final List<HostInfo> hosts = new ArrayList<>();
     result = target.failover(hosts, currentHost);
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
-    assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
+    assertEquals(
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        result.getConnectionIndex());
   }
 
   @Test
@@ -208,7 +232,8 @@ public class ClusterAwareReaderFailoverHandlerTest {
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
     when(mockTopologyService.getDownHosts()).thenReturn(new HashSet<>());
     final ConnectionImpl mockConnection = Mockito.mock(ConnectionImpl.class);
-    final List<HostInfo> hosts = getHostsFromTestUrls(3); // 2 connection attempts (writer not attempted)
+    final List<HostInfo> hosts =
+        getHostsFromTestUrls(3); // 2 connection attempts (writer not attempted)
     final HostInfo slowHost = hosts.get(1);
     final HostInfo fastHost = hosts.get(2);
     final ConnectionProvider mockConnProvider = Mockito.mock(ConnectionProvider.class);
@@ -222,7 +247,11 @@ public class ClusterAwareReaderFailoverHandlerTest {
     when(mockConnProvider.connect(refEq(fastHost))).thenReturn(mockConnection);
 
     final ReaderFailoverHandler target =
-        new ClusterAwareReaderFailoverHandler(mockTopologyService, mockConnProvider, testConnectionProps, mockLog);
+        new ClusterAwareReaderFailoverHandler(
+            mockTopologyService,
+            mockConnProvider,
+            testConnectionProps,
+            mockLog);
     final ReaderFailoverResult result = target.getReaderConnection(hosts);
 
     assertTrue(result.isConnected());
@@ -241,18 +270,25 @@ public class ClusterAwareReaderFailoverHandlerTest {
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
     when(mockTopologyService.getDownHosts()).thenReturn(new HashSet<>());
     final ConnectionProvider mockConnProvider = Mockito.mock(ConnectionProvider.class);
-    final List<HostInfo> hosts = getHostsFromTestUrls(4); // 3 connection attempts (writer not attempted)
+    final List<HostInfo> hosts =
+        getHostsFromTestUrls(4); // 3 connection attempts (writer not attempted)
     when(mockConnProvider.connect(any())).thenThrow(new SQLException());
 
     final int currentHostIndex = 2;
 
     final ReaderFailoverHandler target =
-        new ClusterAwareReaderFailoverHandler(mockTopologyService, mockConnProvider, testConnectionProps, mockLog);
+        new ClusterAwareReaderFailoverHandler(
+            mockTopologyService,
+            mockConnProvider,
+            testConnectionProps,
+            mockLog);
     final ReaderFailoverResult result = target.getReaderConnection(hosts);
 
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
-    assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
+    assertEquals(
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        result.getConnectionIndex());
 
     final HostInfo currentHost = hosts.get(currentHostIndex);
     verify(mockTopologyService, atLeastOnce()).addToDownHostList(eq(currentHost));
@@ -270,7 +306,8 @@ public class ClusterAwareReaderFailoverHandlerTest {
     when(mockTopologyService.getDownHosts()).thenReturn(new HashSet<>());
     final ConnectionProvider mockProvider = Mockito.mock(ConnectionProvider.class);
     final ConnectionImpl mockConnection = Mockito.mock(ConnectionImpl.class);
-    final List<HostInfo> hosts = getHostsFromTestUrls(3); // 2 connection attempts (writer not attempted)
+    final List<HostInfo> hosts =
+        getHostsFromTestUrls(3); // 2 connection attempts (writer not attempted)
     when(mockProvider.connect(any()))
         .thenAnswer(
             (Answer<ConnectionImpl>)
@@ -284,12 +321,20 @@ public class ClusterAwareReaderFailoverHandlerTest {
                 });
 
     final ClusterAwareReaderFailoverHandler target =
-        new ClusterAwareReaderFailoverHandler(mockTopologyService, mockProvider, testConnectionProps, 60000, 1000, mockLog);
+        new ClusterAwareReaderFailoverHandler(
+            mockTopologyService,
+            mockProvider,
+            testConnectionProps,
+            60000,
+            1000,
+            mockLog);
     final ReaderFailoverResult result = target.getReaderConnection(hosts);
 
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
-    assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
+    assertEquals(
+        ClusterAwareConnectionProxy.NO_CONNECTION_INDEX,
+        result.getConnectionIndex());
 
     verify(mockTopologyService, never()).addToDownHostList(any());
   }
@@ -306,7 +351,10 @@ public class ClusterAwareReaderFailoverHandlerTest {
 
     final ClusterAwareReaderFailoverHandler target =
         new ClusterAwareReaderFailoverHandler(
-            Mockito.mock(TopologyService.class), Mockito.mock(ConnectionProvider.class), testConnectionProps, mockLog);
+            Mockito.mock(TopologyService.class),
+            Mockito.mock(ConnectionProvider.class),
+            testConnectionProps,
+            mockLog);
     final List<ClusterAwareReaderFailoverHandler.HostTuple> tuplesByPriority =
         target.getHostTuplesByPriority(originalHosts, downHosts);
 
@@ -353,7 +401,10 @@ public class ClusterAwareReaderFailoverHandlerTest {
 
     final ClusterAwareReaderFailoverHandler target =
         new ClusterAwareReaderFailoverHandler(
-            Mockito.mock(TopologyService.class), Mockito.mock(ConnectionProvider.class), testConnectionProps, mockLog);
+            Mockito.mock(TopologyService.class),
+            Mockito.mock(ConnectionProvider.class),
+            testConnectionProps,
+            mockLog);
     final List<ClusterAwareReaderFailoverHandler.HostTuple> readerTuples =
         target.getReaderTuplesByPriority(originalHosts, downHosts);
 

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareTestUtils.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareTestUtils.java
@@ -38,19 +38,28 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Class containing helper methods for {@link ClusterAwareConnectionProxyTest},
+ * {@link ClusterAwareReaderFailoverHandlerTest} and {@link ClusterAwareWriterFailoverHandlerTest}.
+ */
 public class ClusterAwareTestUtils {
-    protected static HostInfo createBasicHostInfo(String instanceName, String db) {
-        return createBasicHostInfo(instanceName, db, null, null);
-    }
+  protected static HostInfo createBasicHostInfo(String instanceName, String db) {
+    return createBasicHostInfo(instanceName, db, null, null);
+  }
 
-    protected static HostInfo createBasicHostInfo(String instanceName, String db, String user, String password) {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put(TopologyServicePropertyKeys.INSTANCE_NAME, instanceName);
-        String url = "jdbc:mysql:aws://" + instanceName + ".com:1234/";
-        db = db == null ? "" : db;
-        properties.put(PropertyKey.DBNAME.getKeyName(), db);
-        url += db;
-        final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-        return new HostInfo(conStr, instanceName, 1234, user, password, properties);
-    }
+  protected static HostInfo createBasicHostInfo(
+      String instanceName,
+      String db,
+      String user,
+      String password) {
+    final Map<String, String> properties = new HashMap<>();
+    properties.put(TopologyServicePropertyKeys.INSTANCE_NAME, instanceName);
+    String url = "jdbc:mysql:aws://" + instanceName + ".com:1234/";
+    db = (db == null) ? "" : db;
+    properties.put(PropertyKey.DBNAME.getKeyName(), db);
+    url += db;
+    final ConnectionUrl conStr =
+        ConnectionUrl.getConnectionUrlInstance(url, new Properties());
+    return new HostInfo(conStr, instanceName, 1234, user, password, properties);
+  }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorServiceTest.java
@@ -57,7 +57,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultMonitorServiceTest {
-  private static final Set<String> NODE_KEYS = new HashSet<>(Collections.singletonList("any.node.domain"));
+  private static final Set<String> NODE_KEYS =
+      new HashSet<>(Collections.singletonList("any.node.domain"));
   private static final int FAILURE_DETECTION_TIME_MILLIS = 10;
   private static final int FAILURE_DETECTION_INTERVAL_MILLIS = 100;
   private static final int FAILURE_DETECTION_COUNT = 3;
@@ -122,13 +123,13 @@ class DefaultMonitorServiceTest {
     doNothing().when(monitorA).startMonitoring(contextCaptor.capture());
 
     monitorService.startMonitoring(
-      connection,
-      NODE_KEYS,
-      info,
-      propertySet,
-      FAILURE_DETECTION_TIME_MILLIS,
-      FAILURE_DETECTION_INTERVAL_MILLIS,
-      FAILURE_DETECTION_COUNT);
+        connection,
+        NODE_KEYS,
+        info,
+        propertySet,
+        FAILURE_DETECTION_TIME_MILLIS,
+        FAILURE_DETECTION_INTERVAL_MILLIS,
+        FAILURE_DETECTION_COUNT);
 
     assertNotNull(contextCaptor.getValue());
     verify(executorService).submit(eq(monitorA));
@@ -210,12 +211,16 @@ class DefaultMonitorServiceTest {
     assertNotNull(monitorOne);
 
     // Should get the same monitor as before as contain the same key "nodeTwo.domain"
-    final IMonitor monitorOneSame = monitorService.getMonitor(nodeKeysTwo, info, propertySet);
+    final IMonitor monitorOneSame =
+        monitorService.getMonitor(nodeKeysTwo, info, propertySet);
     assertNotNull(monitorOneSame);
     assertEquals(monitorOne, monitorOneSame);
 
     // Make sure createMonitor was called once
-    verify(monitorInitializer).createMonitor(eq(info), eq(propertySet), eq(monitorService));
+    verify(monitorInitializer).createMonitor(
+        eq(info),
+        eq(propertySet),
+        eq(monitorService));
   }
 
   @Test
@@ -227,7 +232,8 @@ class DefaultMonitorServiceTest {
     assertNotNull(monitorOne);
 
     // Ensuring monitor is the same one and not creating a new one
-    final IMonitor monitorOneDupe = monitorService.getMonitor(nodeKeys, info, propertySet);
+    final IMonitor monitorOneDupe =
+        monitorService.getMonitor(nodeKeys, info, propertySet);
     assertEquals(monitorOne, monitorOneDupe);
 
     // Ensuring monitors are not the same as they have different keys
@@ -254,15 +260,20 @@ class DefaultMonitorServiceTest {
 
     // Add a new key using the same monitor
     // Adding "nodeB" as a new key using the same monitor as "nodeA"
-    final IMonitor monitorOneDupe = monitorService.getMonitor(nodeKeysTwo, info, propertySet);
+    final IMonitor monitorOneDupe =
+        monitorService.getMonitor(nodeKeysTwo, info, propertySet);
     assertEquals(monitorOne, monitorOneDupe);
 
     // Using new keyset but same node, "nodeB" should return same monitor
-    final IMonitor monitorOneDupeAgain = monitorService.getMonitor(nodeKeysThree, info, propertySet);
+    final IMonitor monitorOneDupeAgain =
+        monitorService.getMonitor(nodeKeysThree, info, propertySet);
     assertEquals(monitorOne, monitorOneDupeAgain);
 
     // Make sure createMonitor was called once
-    verify(monitorInitializer).createMonitor(eq(info), eq(propertySet), eq(monitorService));
+    verify(monitorInitializer).createMonitor(
+        eq(info),
+        eq(propertySet),
+        eq(monitorService));
   }
 
   @Test

--- a/src/test/java/testsuite/failover/ReplicationFailoverIntegrationTest.java
+++ b/src/test/java/testsuite/failover/ReplicationFailoverIntegrationTest.java
@@ -41,7 +41,10 @@ import com.amazonaws.services.rds.model.FailoverDBClusterRequest;
 import com.mysql.cj.log.Log;
 import com.mysql.cj.log.LogFactory;
 import com.mysql.cj.log.StandardLogger;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import software.aws.rds.jdbc.mysql.Driver;
 
 import java.sql.Connection;
@@ -56,228 +59,239 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+/**
+ * Integration testing with Aurora MySQL replica failover logic.
+ */
 @Disabled
 public class ReplicationFailoverIntegrationTest {
-    /*
-     * Before running these tests we need to initialize the test cluster as the following.
-     *
-     * Expected cluster state:
-     * +------------------+--------+---------+
-     * |   Instance Id    |  Role  | Status  |
-     * +------------------+--------+---------+
-     * | mysql-instance-1 | Writer | Running |
-     * | mysql-instance-2 | Reader | Running |
-     * | mysql-instance-3 | Reader | Running |
-     * | mysql-instance-4 | Reader | Running |
-     * | mysql-instance-5 | Reader | Running |
-     * +------------------+--------+---------+
-     *
-     * */
-    private static final String DB_CONN_STR_PREFIX = "jdbc:mysql:replication://";
-    private static final String DB_CONN_STR_SUFFIX = System.getenv("DB_CONN_STR_SUFFIX");
+  /*
+   * Before running these tests we need to initialize the test cluster as the following.
+   *
+   * Expected cluster state:
+   * +------------------+--------+---------+
+   * |   Instance Id    |  Role  | Status  |
+   * +------------------+--------+---------+
+   * | mysql-instance-1 | Writer | Running |
+   * | mysql-instance-2 | Reader | Running |
+   * | mysql-instance-3 | Reader | Running |
+   * | mysql-instance-4 | Reader | Running |
+   * | mysql-instance-5 | Reader | Running |
+   * +------------------+--------+---------+
+   *
+   * */
+  private static final String DB_CONN_STR_PREFIX = "jdbc:mysql:replication://";
+  private static final String DB_CONN_STR_SUFFIX = System.getenv("DB_CONN_STR_SUFFIX");
 
-    private static final String TEST_DB_CLUSTER_IDENTIFIER =
-            System.getenv("TEST_DB_CLUSTER_IDENTIFIER");
-    private static final String TEST_USERNAME = System.getenv("TEST_USERNAME");
-    private static final String TEST_PASSWORD = System.getenv("TEST_PASSWORD");
-    private static final int TEST_CLUSTER_SIZE = 5;
-    private static String INSTANCE_ID_1 = "";
-    private static String INSTANCE_ID_2 = "";
-    private static String INSTANCE_ID_3 = "";
-    private static String INSTANCE_ID_4 = "";
-    private static String INSTANCE_ID_5 = "";
-    private final List<String> hosts = new ArrayList<>();
-    private static final String NO_WRITER_AVAILABLE =
-            "Cannot get the id of the writer Instance in the cluster.";
+  private static final String TEST_DB_CLUSTER_IDENTIFIER =
+      System.getenv("TEST_DB_CLUSTER_IDENTIFIER");
+  private static final String TEST_USERNAME = System.getenv("TEST_USERNAME");
+  private static final String TEST_PASSWORD = System.getenv("TEST_PASSWORD");
+  private static final int TEST_CLUSTER_SIZE = 5;
+  private static String INSTANCE_ID_1 = "";
+  private static String INSTANCE_ID_2 = "";
+  private static String INSTANCE_ID_3 = "";
+  private static String INSTANCE_ID_4 = "";
+  private static String INSTANCE_ID_5 = "";
+  private final List<String> hosts = new ArrayList<>();
+  private static final String NO_WRITER_AVAILABLE =
+      "Cannot get the id of the writer Instance in the cluster.";
 
-    private final Log log;
+  private final Log log;
 
-    private final AmazonRDS rdsClient = AmazonRDSClientBuilder.standard().build();
+  private final AmazonRDS rdsClient = AmazonRDSClientBuilder.standard().build();
 
-    /**
-     * ReplicationFailoverIntegrationTest constructor.
-     * */
-    public ReplicationFailoverIntegrationTest() throws SQLException {
-        DriverManager.registerDriver(new Driver());
-        this.log = LogFactory.getLogger(StandardLogger.class.getName(), Log.LOGGER_INSTANCE_NAME);
+  /**
+   * ReplicationFailoverIntegrationTest constructor.
+   */
+  public ReplicationFailoverIntegrationTest() throws SQLException {
+    DriverManager.registerDriver(new Driver());
+    this.log =
+        LogFactory.getLogger(StandardLogger.class.getName(), Log.LOGGER_INSTANCE_NAME);
 
-        initiateInstanceNames();
-        hosts.add(INSTANCE_ID_1);
-        hosts.add(INSTANCE_ID_2);
-        hosts.add(INSTANCE_ID_3);
-        hosts.add(INSTANCE_ID_4);
-        hosts.add(INSTANCE_ID_5);
+    initiateInstanceNames();
+    hosts.add(INSTANCE_ID_1);
+    hosts.add(INSTANCE_ID_2);
+    hosts.add(INSTANCE_ID_3);
+    hosts.add(INSTANCE_ID_4);
+    hosts.add(INSTANCE_ID_5);
+  }
+
+  @Test
+  @Timeout(3 * 60000)
+  public void testReplicationFailover() throws SQLException {
+    final String initalWriterInstance = INSTANCE_ID_1;
+    String replicationHosts = getReplicationHosts();
+
+    Connection testConnection =
+        DriverManager.getConnection(DB_CONN_STR_PREFIX + replicationHosts,
+            TEST_USERNAME,
+            TEST_PASSWORD);
+
+    // Switch to a replica
+    testConnection.setReadOnly(true);
+    String replicaInstance = queryInstanceId(testConnection);
+    assertNotEquals(initalWriterInstance, replicaInstance);
+    rebootInstance(replicaInstance);
+
+    try {
+      while (true) {
+        queryInstanceId(testConnection);
+      }
+    } catch (SQLException e) {
+      // do nothing
     }
 
-    @Test
-    @Timeout(3 * 60000)
-    public void testReplicationFailover() throws SQLException {
-        final String initalWriterInstance = INSTANCE_ID_1;
-        String replicationHosts = getReplicationHosts();
+    // Assert that we are connected to the new replica after failover happens.
+    final String newInstance = queryInstanceId(testConnection);
+    assertNotEquals(newInstance, replicaInstance);
+    assertNotEquals(newInstance, initalWriterInstance);
+  }
 
-        Connection testConnection = DriverManager.getConnection(DB_CONN_STR_PREFIX + replicationHosts, TEST_USERNAME, TEST_PASSWORD);
+  private String getReplicationHosts() {
+    StringBuilder hostsStringBuilder = new StringBuilder();
+    int numHosts = 3;
+    for (int i = 0; i < numHosts; i++) {
+      hostsStringBuilder.append(hosts.get(i)).append(DB_CONN_STR_SUFFIX);
+      if (i < numHosts - 1) {
+        hostsStringBuilder.append(",");
+      }
+    }
+    return hostsStringBuilder.toString();
+  }
 
-        // Switch to a replica
-        testConnection.setReadOnly(true);
-        String replicaInstance = queryInstanceId(testConnection);
-        assertNotEquals(initalWriterInstance, replicaInstance);
-        rebootInstance(replicaInstance);
-        
-        try {
-            while (true) {
-                queryInstanceId(testConnection);
-            } 
-        } catch (SQLException e) {
-            // do nothing
-        }
+  private void rebootInstance(String instance) {
+    RebootDBInstanceRequest rebootRequest =
+        new RebootDBInstanceRequest().withDBInstanceIdentifier(instance);
+    rdsClient.rebootDBInstance(rebootRequest);
+  }
 
-        // Assert that we are connected to the new replica after failover happens.
-        final String newInstance = queryInstanceId(testConnection);
-        assertNotEquals(newInstance, replicaInstance);
-        assertNotEquals(newInstance, initalWriterInstance);
+  private DBCluster getDBCluster() {
+    DescribeDBClustersRequest dbClustersRequest =
+        new DescribeDBClustersRequest().withDBClusterIdentifier(TEST_DB_CLUSTER_IDENTIFIER);
+    DescribeDBClustersResult dbClustersResult =
+        rdsClient.describeDBClusters(dbClustersRequest);
+    List<DBCluster> dbClusterList = dbClustersResult.getDBClusters();
+    return dbClusterList.get(0);
+  }
+
+  private void initiateInstanceNames() {
+    this.log.logDebug("Initiating db instance names.");
+    List<DBClusterMember> dbClusterMembers = getDBClusterMemberList();
+
+    assertEquals(TEST_CLUSTER_SIZE, dbClusterMembers.size());
+    INSTANCE_ID_1 = dbClusterMembers.get(0).getDBInstanceIdentifier();
+    INSTANCE_ID_2 = dbClusterMembers.get(1).getDBInstanceIdentifier();
+    INSTANCE_ID_3 = dbClusterMembers.get(2).getDBInstanceIdentifier();
+    INSTANCE_ID_4 = dbClusterMembers.get(3).getDBInstanceIdentifier();
+    INSTANCE_ID_5 = dbClusterMembers.get(4).getDBInstanceIdentifier();
+  }
+
+  private List<DBClusterMember> getDBClusterMemberList() {
+    DBCluster dbCluster = getDBCluster();
+    return dbCluster.getDBClusterMembers();
+  }
+
+  private String getDBClusterWriterInstanceId() {
+    List<DBClusterMember> matchedMemberList =
+        getDBClusterMemberList().stream()
+            .filter(DBClusterMember::isClusterWriter)
+            .collect(Collectors.toList());
+    if (matchedMemberList.isEmpty()) {
+      throw new RuntimeException(NO_WRITER_AVAILABLE);
+    }
+    // Should be only one writer at index 0.
+    return matchedMemberList.get(0).getDBInstanceIdentifier();
+  }
+
+  private void failoverClusterWithATargetInstance(String targetInstanceId)
+      throws InterruptedException {
+    this.log.logDebug("Failover cluster to " + targetInstanceId);
+    waitUntilClusterHasRightState();
+    FailoverDBClusterRequest request =
+        new FailoverDBClusterRequest()
+            .withDBClusterIdentifier(TEST_DB_CLUSTER_IDENTIFIER)
+            .withTargetDBInstanceIdentifier(targetInstanceId);
+
+    while (true) {
+      try {
+        rdsClient.failoverDBCluster(request);
+        break;
+      } catch (Exception e) {
+        Thread.sleep(3000);
+      }
     }
 
-    private String getReplicationHosts() {
-        StringBuilder hostsStringBuilder = new StringBuilder();
-        int numHosts = 3;
-        for(int i = 0; i < numHosts; i++) {
-            hostsStringBuilder.append(hosts.get(i)).append(DB_CONN_STR_SUFFIX);
-            if (i < numHosts - 1) {
-                hostsStringBuilder.append(",");
-            }
-        }
-        return hostsStringBuilder.toString();
+    this.log.logDebug("Cluster failover request successful.");
+  }
+
+  private void waitUntilClusterHasRightState() throws InterruptedException {
+    this.log.logDebug("Wait until cluster is in available state.");
+    String status = getDBCluster().getStatus();
+    while (!"available".equalsIgnoreCase(status)) {
+      Thread.sleep(3000);
+      status = getDBCluster().getStatus();
     }
+    this.log.logDebug("Cluster is available.");
+  }
 
-    private void rebootInstance(String instance) {
-        RebootDBInstanceRequest rebootRequest = new RebootDBInstanceRequest().withDBInstanceIdentifier(instance);
-        rdsClient.rebootDBInstance(rebootRequest);
+  private Connection createConnectionWithProxyDisabled(String instanceID)
+      throws SQLException {
+    return DriverManager.getConnection(
+        DB_CONN_STR_PREFIX + instanceID + DB_CONN_STR_SUFFIX
+            + "?enableClusterAwareFailover=false",
+        TEST_USERNAME,
+        TEST_PASSWORD);
+  }
+
+  private String queryInstanceId(Connection connection) throws SQLException {
+    try (Statement myStmt = connection.createStatement();
+         ResultSet resultSet = myStmt.executeQuery("select @@aurora_server_id")
+    ) {
+      if (resultSet.next()) {
+        return resultSet.getString("@@aurora_server_id");
+      }
     }
+    throw new SQLException();
+  }
 
-    private DBCluster getDBCluster() {
-        DescribeDBClustersRequest dbClustersRequest =
-                new DescribeDBClustersRequest().withDBClusterIdentifier(TEST_DB_CLUSTER_IDENTIFIER);
-        DescribeDBClustersResult dbClustersResult = rdsClient.describeDBClusters(dbClustersRequest);
-        List<DBCluster> dbClusterList = dbClustersResult.getDBClusters();
-        return dbClusterList.get(0);
+  private void waitUntilFirstInstanceIsWriter() throws InterruptedException {
+    this.log.logDebug("Failover cluster to Instance 1.");
+    failoverClusterWithATargetInstance(INSTANCE_ID_1);
+    String clusterWriterId = getDBClusterWriterInstanceId();
+
+    this.log.logDebug("Wait until Instance 1 becomes the writer.");
+    while (!INSTANCE_ID_1.equals(clusterWriterId)) {
+      clusterWriterId = getDBClusterWriterInstanceId();
+      System.out.println("Writer is still " + clusterWriterId);
+      Thread.sleep(3000);
     }
+  }
 
-    private void initiateInstanceNames() {
-        this.log.logDebug("Initiating db instance names.");
-        List<DBClusterMember> dbClusterMembers = getDBClusterMemberList();
-
-        assertEquals(TEST_CLUSTER_SIZE, dbClusterMembers.size());
-        INSTANCE_ID_1 = dbClusterMembers.get(0).getDBInstanceIdentifier();
-        INSTANCE_ID_2 = dbClusterMembers.get(1).getDBInstanceIdentifier();
-        INSTANCE_ID_3 = dbClusterMembers.get(2).getDBInstanceIdentifier();
-        INSTANCE_ID_4 = dbClusterMembers.get(3).getDBInstanceIdentifier();
-        INSTANCE_ID_5 = dbClusterMembers.get(4).getDBInstanceIdentifier();
+  /**
+   * Block until the specified instance is accessible again.
+   */
+  public void waitUntilInstanceIsUp(String instanceId) throws InterruptedException {
+    this.log.logDebug("Wait until " + instanceId + " is up.");
+    while (true) {
+      try (Connection conn = createConnectionWithProxyDisabled(instanceId)) {
+        conn.close();
+        break;
+      } catch (SQLException ex) {
+        // Continue waiting until instance is up.
+      }
+      Thread.sleep(3000);
     }
+    this.log.logDebug(instanceId + " is up.");
+  }
 
-    private List<DBClusterMember> getDBClusterMemberList() {
-        DBCluster dbCluster = getDBCluster();
-        return dbCluster.getDBClusterMembers();
-    }
-
-    private String getDBClusterWriterInstanceId() {
-        List<DBClusterMember> matchedMemberList =
-                getDBClusterMemberList().stream()
-                        .filter(DBClusterMember::isClusterWriter)
-                        .collect(Collectors.toList());
-        if (matchedMemberList.isEmpty()) {
-            throw new RuntimeException(NO_WRITER_AVAILABLE);
-        }
-        // Should be only one writer at index 0.
-        return matchedMemberList.get(0).getDBInstanceIdentifier();
-    }
-
-    private void failoverClusterWithATargetInstance(String targetInstanceId)
-            throws InterruptedException {
-        this.log.logDebug("Failover cluster to " + targetInstanceId);
-        waitUntilClusterHasRightState();
-        FailoverDBClusterRequest request =
-                new FailoverDBClusterRequest()
-                        .withDBClusterIdentifier(TEST_DB_CLUSTER_IDENTIFIER)
-                        .withTargetDBInstanceIdentifier(targetInstanceId);
-
-        while (true) {
-            try {
-                rdsClient.failoverDBCluster(request);
-                break;
-            } catch (Exception e) {
-                Thread.sleep(3000);
-            }
-        }
-
-        this.log.logDebug("Cluster failover request successful.");
-    }
-
-    private void waitUntilClusterHasRightState() throws InterruptedException {
-        this.log.logDebug("Wait until cluster is in available state.");
-        String status = getDBCluster().getStatus();
-        while (!"available".equalsIgnoreCase(status)) {
-            Thread.sleep(3000);
-            status = getDBCluster().getStatus();
-        }
-        this.log.logDebug("Cluster is available.");
-    }
-
-    private Connection createConnectionWithProxyDisabled(String instanceID) throws SQLException {
-        return DriverManager.getConnection(
-                DB_CONN_STR_PREFIX + instanceID + DB_CONN_STR_SUFFIX + "?enableClusterAwareFailover=false",
-                TEST_USERNAME,
-                TEST_PASSWORD);
-    }
-
-    private String queryInstanceId(Connection connection) throws SQLException {
-        try (Statement myStmt = connection.createStatement();
-             ResultSet resultSet = myStmt.executeQuery("select @@aurora_server_id")
-        ) {
-            if (resultSet.next()) {
-                return resultSet.getString("@@aurora_server_id");
-            }
-        }
-        throw new SQLException();
-    }
-
-    private void waitUntilFirstInstanceIsWriter() throws InterruptedException {
-        this.log.logDebug("Failover cluster to Instance 1.");
-        failoverClusterWithATargetInstance(INSTANCE_ID_1);
-        String clusterWriterId = getDBClusterWriterInstanceId();
-
-        this.log.logDebug("Wait until Instance 1 becomes the writer.");
-        while (!INSTANCE_ID_1.equals(clusterWriterId)) {
-            clusterWriterId = getDBClusterWriterInstanceId();
-            System.out.println("Writer is still " + clusterWriterId);
-            Thread.sleep(3000);
-        }
-    }
-
-    /**
-     * Block until the specified instance is accessible again.
-     * */
-    public void waitUntilInstanceIsUp(String instanceId) throws InterruptedException {
-        this.log.logDebug("Wait until " + instanceId + " is up.");
-        while (true) {
-            try (Connection conn = createConnectionWithProxyDisabled(instanceId)) {
-                conn.close();
-                break;
-            } catch (SQLException ex) {
-                // Continue waiting until instance is up.
-            }
-            Thread.sleep(3000);
-        }
-        this.log.logDebug(instanceId + " is up.");
-    }
-
-    @BeforeEach
-    private void resetCluster() throws InterruptedException {
-        this.log.logDebug("Resetting cluster.");
-        waitUntilFirstInstanceIsWriter();
-        waitUntilInstanceIsUp(INSTANCE_ID_1);
-        waitUntilInstanceIsUp(INSTANCE_ID_2);
-        waitUntilInstanceIsUp(INSTANCE_ID_3);
-        waitUntilInstanceIsUp(INSTANCE_ID_4);
-        waitUntilInstanceIsUp(INSTANCE_ID_5);
-    }
+  @BeforeEach
+  private void resetCluster() throws InterruptedException {
+    this.log.logDebug("Resetting cluster.");
+    waitUntilFirstInstanceIsWriter();
+    waitUntilInstanceIsUp(INSTANCE_ID_1);
+    waitUntilInstanceIsUp(INSTANCE_ID_2);
+    waitUntilInstanceIsUp(INSTANCE_ID_3);
+    waitUntilInstanceIsUp(INSTANCE_ID_4);
+    waitUntilInstanceIsUp(INSTANCE_ID_5);
+  }
 }


### PR DESCRIPTION
### Summary

Address warnings reported by the Checkstyle plugin.
Only warnings remaining are related to missing Javadoc, which will be added in a separate PR.

### Description

Types of warnings addressed:
- wrong indentation level
- missing whitespaces
- missing ending period in Javadoc comment.

### Additional Reviewers

@sergiyv-bitquill 
@ColinKYuen 
@matthewh-BQ 