### PR TITLE
Add Javadoc (part 1) and extra fixes

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -305,7 +305,7 @@
       <property name="scope" value="public"/>
       <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+      <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>
     </module>
     <module name="MissingJavadocType">

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -888,7 +888,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       throws SQLException {
     HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(
         baseHostInfo,
-        this.initialConnectionProps);
+        this.connectionUrl);
     ConnectionImpl conn = this.connectionProvider.connect(hostInfoWithInitialProps);
     setConnectionProxy(conn);
     return conn;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
@@ -78,6 +78,7 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
   protected final ConnectionProvider connProvider;
   protected final TopologyService topologyService;
 
+  /** ClusterAwareReaderFailoverHandler constructor. */
   public ClusterAwareReaderFailoverHandler(
       TopologyService topologyService,
       ConnectionProvider connProvider,

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
@@ -78,7 +78,15 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
   protected final ConnectionProvider connProvider;
   protected final TopologyService topologyService;
 
-  /** ClusterAwareReaderFailoverHandler constructor. */
+  /**
+   * ClusterAwareReaderFailoverHandler constructor.
+   *
+   * @param topologyService An implementation of {@link TopologyService} that obtains and
+   *                        caches a cluster's topology.
+   * @param connProvider A provider for creating new connections.
+   * @param initialConnectionProps The initial connection properties to copy over to the
+   *                               new reader.
+   */
   public ClusterAwareReaderFailoverHandler(
       TopologyService topologyService,
       ConnectionProvider connProvider,
@@ -93,10 +101,19 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
         log);
   }
 
-
   /**
    * ClusterAwareReaderFailoverHandler constructor.
-   * */
+   *
+   * @param topologyService An implementation of {@link TopologyService} that obtains and
+   *                        caches a cluster's topology.
+   * @param connProvider A provider for creating new connections.
+   * @param initialConnectionProps The initial connection properties to copy over to the
+   *                               new reader.
+   * @param failoverTimeoutMs Maximum allowed time in milliseconds to attempt reconnecting
+   *                         to a new reader instance after a cluster failover is initiated.
+   * @param timeoutMs Maximum allowed time for the entire reader failover process.
+   * @param log An implementation of {@link Log}.
+   */
   public ClusterAwareReaderFailoverHandler(
       TopologyService topologyService,
       ConnectionProvider connProvider,

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
@@ -38,6 +38,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Utility class for copying {@link HostInfo} objects.
+ */
 public class ClusterAwareUtils {
   /**
    * Create a copy of the given {@link HostInfo} object where all details are the same except for the host properties,

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * It's a generic interface for all topology services. It's expected that every implementation of
  * topology service covers different cluster types or cluster deployment.
  *
- * <p>It's expected that each instance of ClusterAwareConnectionProxy uses it's own instance of
+ * <p>It's expected that each instance of ClusterAwareConnectionProxy uses its own instance of
  * topology service.
  */
 public interface TopologyService {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -58,6 +58,9 @@ public class ConnectionPluginManager {
     Runtime.getRuntime().addShutdownHook(new Thread(ConnectionPluginManager::releaseAllResources));
   }
 
+  /**
+   * Constructor.
+   */
   public ConnectionPluginManager(Log logger) {
     if (logger == null) {
       throw new IllegalArgumentException(NullArgumentMessage.getMessage("logger"));
@@ -120,6 +123,15 @@ public class ConnectionPluginManager {
 
   }
 
+  /**
+   * Execute a JDBC method with the connection plugin chain.
+   *
+   * @param methodInvokeOn The Java Class invoking the JDBC method.
+   * @param methodName The name of the method being invoked.
+   * @param executeSqlFunc A lambda executing the method.
+   * @return the result from the execution.
+   * @throws Exception if errors occurred during the execution.
+   */
   public Object execute(
       Class<?> methodInvokeOn,
       String methodName,
@@ -127,12 +139,19 @@ public class ConnectionPluginManager {
     return this.headPlugin.execute(methodInvokeOn, methodName, executeSqlFunc);
   }
 
+  /**
+   * Release all dangling resources held by the connection plugins associated with
+   * a single connection.
+   */
   public void releaseResources() {
     instances.remove(this);
     this.logger.logTrace("[ConnectionPluginManager.releaseResources]");
     this.headPlugin.releaseResources();
   }
 
+  /**
+   * Release all dangling resources for all connection plugin managers.
+   */
   public static void releaseAllResources() {
     instances.forEach(ConnectionPluginManager::releaseResources);
   }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -58,9 +58,6 @@ public class ConnectionPluginManager {
     Runtime.getRuntime().addShutdownHook(new Thread(ConnectionPluginManager::releaseAllResources));
   }
 
-  /**
-   * Constructor.
-   */
   public ConnectionPluginManager(Log logger) {
     if (logger == null) {
       throw new IllegalArgumentException(NullArgumentMessage.getMessage("logger"));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -39,7 +39,6 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
 
   protected Log logger;
 
-  /** Constructor. */
   public DefaultConnectionPlugin(Log logger) {
     if (logger == null) {
       throw new IllegalArgumentException(NullArgumentMessage.getMessage("logger"));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -31,10 +31,15 @@ import com.mysql.cj.log.Log;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 
+/**
+ * This connection plugin will always be the last plugin in the connection plugin chain,
+ * and will invoke the JDBC method passed down the chain.
+ */
 public class DefaultConnectionPlugin implements IConnectionPlugin {
 
   protected Log logger;
 
+  /** Constructor. */
   public DefaultConnectionPlugin(Log logger) {
     if (logger == null) {
       throw new IllegalArgumentException(NullArgumentMessage.getMessage("logger"));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPluginFactory.java
@@ -29,6 +29,9 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
+/**
+ * Initialize a {@link DefaultConnectionPlugin}.
+ */
 public class DefaultConnectionPluginFactory implements IConnectionPluginFactory {
   @Override
   public IConnectionPlugin getInstance(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -47,7 +47,6 @@ public class DefaultMonitorService implements IMonitorService {
   private final Log logger;
   final IMonitorInitializer monitorInitializer;
 
-  /** Constructor. */
   public DefaultMonitorService(Log logger) {
     this(
         (hostInfo, propertySet, monitorService) -> new Monitor(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -37,12 +37,17 @@ import com.mysql.cj.log.Log;
 import java.util.Set;
 import java.util.concurrent.Executors;
 
+/**
+ * This class handles the creation and clean up of monitoring threads to servers with one
+ * or more active connections.
+ */
 public class DefaultMonitorService implements IMonitorService {
   MonitorThreadContainer threadContainer;
 
   private final Log logger;
   final IMonitorInitializer monitorInitializer;
 
+  /** Constructor. */
   public DefaultMonitorService(Log logger) {
     this(
         (hostInfo, propertySet, monitorService) -> new Monitor(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPlugin.java
@@ -28,6 +28,10 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import java.util.concurrent.Callable;
 
+/**
+ * Interface for connection plugins. This class implements ways to execute a JDBC method
+ * and to clean up resources used before closing the plugin.
+ */
 public interface IConnectionPlugin {
   Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc)
       throws Exception;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IConnectionPluginFactory.java
@@ -29,6 +29,10 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
+/**
+ * Interface for connection plugin factories. This class implements ways to initialize a
+ * connection plugin.
+ */
 public interface IConnectionPluginFactory {
   IConnectionPlugin getInstance(ICurrentConnectionProvider currentConnectionProvider, PropertySet propertySet, IConnectionPlugin nextPlugin, Log logger);
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ICurrentConnectionProvider.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ICurrentConnectionProvider.java
@@ -31,6 +31,9 @@ import com.mysql.cj.jdbc.JdbcConnection;
 
 import java.sql.Connection;
 
+/**
+ * Interface for retrieving the current active {@link JdbcConnection} and its {@link HostInfo}.
+ */
 public interface ICurrentConnectionProvider {
   JdbcConnection getCurrentConnection();
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IExecutorServiceInitializer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IExecutorServiceInitializer.java
@@ -28,6 +28,9 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import java.util.concurrent.ExecutorService;
 
+/**
+ * Interface for passing a specific {@link ExecutorService} to use by the {@link MonitorThreadContainer}.
+ */
 @FunctionalInterface
 public interface IExecutorServiceInitializer {
   ExecutorService createExecutorService();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitor.java
@@ -26,6 +26,10 @@
 
 package com.mysql.cj.jdbc.ha.ca.plugins;
 
+/**
+ * Interface for monitors. This class uses background threads to monitor servers with one
+ * or more connections for more efficient failure detection during method execution.
+ */
 public interface IMonitor extends Runnable {
   void startMonitoring(MonitorConnectionContext context);
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorInitializer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorInitializer.java
@@ -29,6 +29,9 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertySet;
 
+/**
+ * Interface for initialize a new {@link Monitor}.
+ */
 @FunctionalInterface
 public interface IMonitorInitializer {
   IMonitor createMonitor(HostInfo hostInfo, PropertySet propertySet, IMonitorService monitorService);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/IMonitorService.java
@@ -32,6 +32,10 @@ import com.mysql.cj.jdbc.JdbcConnection;
 
 import java.util.Set;
 
+/**
+ * Interface for monitor services. This class implements ways to start and stop monitoring
+ * servers when connections are created.
+ */
 public interface IMonitorService {
   MonitorConnectionContext startMonitoring(
       JdbcConnection connectionToAbort,
@@ -53,7 +57,7 @@ public interface IMonitorService {
   /**
    * Stop monitoring the node for all connections represented by the given set of node keys.
    *
-   * @param nodeKeys All known references to an Aurora node.
+   * @param nodeKeys All known references to a server.
    */
   void stopMonitoringForAllConnections(Set<String> nodeKeys);
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -43,6 +43,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * This class uses a background thread to monitor each server with one or more active
+ * {@link Connection}.
+ */
 public class Monitor implements IMonitor {
   static class ConnectionStatus {
     boolean isValid;
@@ -69,6 +73,20 @@ public class Monitor implements IMonitor {
   private final IMonitorService monitorService;
   private final AtomicBoolean stopped = new AtomicBoolean(true);
 
+  /**
+   * Store the monitoring configuration for a connection.
+   *
+   * @param connectionProvider A provider for creating new connections.
+   * @param hostInfo The {@link HostInfo} of the server this {@link Monitor} instance is
+   *                 monitoring.
+   * @param propertySet The {@link PropertySet} containing additional monitoring configuration.
+   * @param monitorDisposalTime Time before stopping the monitoring thread where there are
+   *                            no active connection to the server this {@link Monitor}
+   *                            instance is monitoring.
+   * @param monitorService A reference to the {@link DefaultMonitorService} implementation
+   *                       that initialized this class.
+   * @param logger A {@link Log} implementation.
+   */
   public Monitor(
       ConnectionProvider connectionProvider,
       HostInfo hostInfo,
@@ -128,8 +146,7 @@ public class Monitor implements IMonitor {
           for (MonitorConnectionContext monitorContext : this.contexts) {
             monitorContext.updateConnectionStatus(
                 currentTime,
-                status.isValid,
-                this.connectionCheckIntervalMillis);
+                status.isValid);
           }
 
           TimeUnit.MILLISECONDS.sleep(Math.max(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/Monitor.java
@@ -44,8 +44,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * This class uses a background thread to monitor each server with one or more active
- * {@link Connection}.
+ * This class uses a background thread to monitor a particular server with one or more
+ * active {@link Connection}.
  */
 public class Monitor implements IMonitor {
   static class ConnectionStatus {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
@@ -58,9 +58,10 @@ public class MonitorConnectionContext {
    *                          that will be aborted in case of server failure.
    * @param nodeKeys All valid references to the server.
    * @param log A {@link Log} implementation.
-   * @param failureDetectionTimeMillis Grace period during which failures are ignored.
-   * @param failureDetectionIntervalMillis How often failures are checked.
-   * @param failureDetectionCount Number of failures before considering the connection dead.
+   * @param failureDetectionTimeMillis Grace period after which node monitoring starts.
+   * @param failureDetectionIntervalMillis Interval between each failed connection check.
+   * @param failureDetectionCount Number of failed connection checks before considering
+   *                              database node as unhealthy.
    */
   public MonitorConnectionContext(
       JdbcConnection connectionToAbort,
@@ -184,8 +185,7 @@ public class MonitorConnectionContext {
 
       final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
       final long maxInvalidNodeDurationMillis =
-          (long) this.getFailureDetectionIntervalMillis()
-              * this.getFailureDetectionCount();
+          (long) this.getFailureDetectionIntervalMillis() * this.getFailureDetectionCount();
 
       if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
         this.log.logTrace(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContext.java
@@ -32,6 +32,10 @@ import com.mysql.cj.log.Log;
 import java.sql.SQLException;
 import java.util.Set;
 
+/**
+ * Monitoring context for each connection. This contains each connection's criteria for
+ * whether a server should be considered unhealthy.
+ */
 public class MonitorConnectionContext {
   private final int failureDetectionIntervalMillis;
   private final int failureDetectionTimeMillis;
@@ -47,6 +51,17 @@ public class MonitorConnectionContext {
   private boolean nodeUnhealthy;
   private boolean activeContext = true;
 
+  /**
+   * Constructor.
+   *
+   * @param connectionToAbort A reference to the connection associated with this context
+   *                          that will be aborted in case of server failure.
+   * @param nodeKeys All valid references to the server.
+   * @param log A {@link Log} implementation.
+   * @param failureDetectionTimeMillis Grace period during which failures are ignored.
+   * @param failureDetectionIntervalMillis How often failures are checked.
+   * @param failureDetectionCount Number of failures before considering the connection dead.
+   */
   public MonitorConnectionContext(
       JdbcConnection connectionToAbort,
       Set<String> nodeKeys,
@@ -137,10 +152,15 @@ public class MonitorConnectionContext {
     }
   }
 
+  /**
+   * Update whether the connection is still valid.
+   *
+   * @param currentTime The time when this method is called.
+   * @param isValid Whether the connection is valid.
+   */
   public void updateConnectionStatus(
       long currentTime,
-      boolean isValid,
-      long validationIntervalTimeMillis) {
+      boolean isValid) {
     if (!this.activeContext) {
       return;
     }
@@ -148,14 +168,13 @@ public class MonitorConnectionContext {
     final long totalElapsedTimeMillis = currentTime - this.startMonitorTime;
 
     if (totalElapsedTimeMillis > this.failureDetectionTimeMillis) {
-      this.setConnectionValid(isValid, currentTime, validationIntervalTimeMillis);
+      this.setConnectionValid(isValid, currentTime);
     }
   }
 
   void setConnectionValid(
       boolean connectionValid,
-      long currentTime,
-      long validationIntervalTimeMillis) {
+      long currentTime) {
     if (!connectionValid) {
       this.failureCount++;
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
@@ -55,7 +55,7 @@ public class MonitorThreadContainer {
   /**
    * Create an instance of the {@link MonitorThreadContainer}.
    *
-   * @return an instance of
+   * @return a singleton instance of the {@link MonitorThreadContainer}.
    */
   public static MonitorThreadContainer getInstance() {
     return getInstance(Executors::newCachedThreadPool);
@@ -73,7 +73,7 @@ public class MonitorThreadContainer {
   }
 
   /**
-   * Release resources held in the the {@link MonitorThreadContainer} and clear reference
+   * Release resources held in the {@link MonitorThreadContainer} and clear references
    * to the container.
    */
   public static void releaseInstance() {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorThreadContainer.java
@@ -39,6 +39,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+/**
+ * This singleton class keeps track of all the monitoring threads and handles the creation
+ * and clean up of each monitoring thread.
+ */
 public class MonitorThreadContainer {
   private static MonitorThreadContainer singleton = null;
   private static final AtomicInteger CLASS_USAGE_COUNT = new AtomicInteger();
@@ -48,6 +52,11 @@ public class MonitorThreadContainer {
   private final ExecutorService threadPool;
   private static final Object LOCK_OBJECT = new Object();
 
+  /**
+   * Create an instance of the {@link MonitorThreadContainer}.
+   *
+   * @return an instance of
+   */
   public static MonitorThreadContainer getInstance() {
     return getInstance(Executors::newCachedThreadPool);
   }
@@ -63,6 +72,10 @@ public class MonitorThreadContainer {
     return singleton;
   }
 
+  /**
+   * Release resources held in the the {@link MonitorThreadContainer} and clear reference
+   * to the container.
+   */
   public static void releaseInstance() {
     if (singleton == null) {
       return;
@@ -154,6 +167,12 @@ public class MonitorThreadContainer {
     availableMonitors.add(monitor);
   }
 
+  /**
+   * Remove references to the given {@link Monitor} object and stop the background monitoring
+   * thread.
+   *
+   * @param monitor The {@link Monitor} representing a monitoring thread.
+   */
   public void releaseResource(IMonitor monitor) {
     if (monitor == null) {
       return;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -45,9 +45,14 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
+/**
+ * Monitor the server while the connection is executing methods for more flexible
+ * failure detection.
+ */
 public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
 
-  private static final String RETRIEVE_HOST_PORT_SQL = "SELECT CONCAT(@@hostname, ':', @@port)";
+  private static final String RETRIEVE_HOST_PORT_SQL =
+      "SELECT CONCAT(@@hostname, ':', @@port)";
   private static final List<String> METHODS_STARTING_WITH = Arrays.asList("get", "abort");
   private static final List<String> METHODS_EQUAL_TO = Arrays.asList("close", "next");
 
@@ -60,6 +65,15 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
   private final ICurrentConnectionProvider currentConnectionProvider;
   private JdbcConnection connection;
 
+  /**
+   * Initialize the node monitoring plugin.
+   *
+   * @param currentConnectionProvider A provider allowing the plugin to retrieve the
+   *                                  current active connection and its connection settings.
+   * @param propertySet The property set used to initialize the active connection.
+   * @param nextPlugin The next connection plugin in the chain.
+   * @param logger An implementation of {@link Log}.
+   */
   public NodeMonitoringConnectionPlugin(
       ICurrentConnectionProvider currentConnectionProvider,
       PropertySet propertySet,
@@ -105,7 +119,10 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
    * @throws Exception if an error occurs.
    */
   @Override
-  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
+  public Object execute(
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<?> executeSqlFunc) throws Exception {
     // update config settings since they may change
     final boolean isEnabled = this.propertySet
         .getBooleanProperty(PropertyKey.nativeFailureDetectionEnabled)
@@ -135,7 +152,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     try {
       this.logger.logTrace(String.format(
           "[NodeMonitoringConnectionPlugin.execute]: method=%s.%s, monitoring is activated",
-              methodInvokeOn.getName(), methodName));
+          methodInvokeOn.getName(),
+          methodName));
 
       this.checkIfChanged(this.currentConnectionProvider.getCurrentConnection());
 
@@ -162,7 +180,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
       }
       this.logger.logTrace(String.format(
           "[NodeMonitoringConnectionPlugin.execute]: method=%s.%s, monitoring is deactivated",
-              methodInvokeOn.getName(), methodName));
+          methodInvokeOn.getName(),
+          methodName));
     }
 
     return result;
@@ -258,7 +277,8 @@ public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {
     }
 
     this.nodeKeys.add(
-        String.format("%s:%s",
+        String.format(
+            "%s:%s",
             hostInfo.getHost(),
             hostInfo.getPort()
         ));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPlugin.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 /**
- * Monitor the server while the connection is executing methods for more flexible
+ * Monitor the server while the connection is executing methods for more sophisticated
  * failure detection.
  */
 public class NodeMonitoringConnectionPlugin implements IConnectionPlugin {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NodeMonitoringConnectionPluginFactory.java
@@ -29,6 +29,9 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
+/**
+ * Class initializing a {@link NodeMonitoringConnectionPlugin}.
+ */
 public class NodeMonitoringConnectionPluginFactory implements IConnectionPluginFactory {
   @Override
   public IConnectionPlugin getInstance(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NullArgumentMessage.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/NullArgumentMessage.java
@@ -28,9 +28,18 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.Messages;
 
+/**
+ * Utility class constructing messages for null arguments.
+ */
 public class NullArgumentMessage {
   private static final String ERROR_MESSAGE_KEY = "IllegalArgumentException.NullParameter";
 
+  /**
+   * Return a message indicating the given {@code param} is null.
+   *
+   * @param param The name of the parameter that is null.
+   * @return a message the parameter passed to the caller method is null.
+   */
   public static String getMessage(String param) {
     return Messages.getString(ERROR_MESSAGE_KEY, new String[] { param });
   }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContextTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/plugins/MonitorConnectionContextTest.java
@@ -67,14 +67,14 @@ class MonitorConnectionContextTest {
 
   @Test
   public void test_1_isNodeUnhealthyWithConnection_returnFalse() {
-    context.setConnectionValid(true, System.currentTimeMillis(), VALIDATION_INTERVAL_MILLIS);
+    context.setConnectionValid(true, System.currentTimeMillis());
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(0, this.context.getFailureCount());
   }
 
   @Test
   public void test_2_isNodeUnhealthyWithInvalidConnection_returnFalse() {
-    context.setConnectionValid(false, System.currentTimeMillis(), VALIDATION_INTERVAL_MILLIS);
+    context.setConnectionValid(false, System.currentTimeMillis());
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(1, this.context.getFailureCount());
   }
@@ -85,7 +85,7 @@ class MonitorConnectionContextTest {
     context.setFailureCount(FAILURE_DETECTION_COUNT);
     context.resetInvalidNodeStartTime();
 
-    context.setConnectionValid(false, System.currentTimeMillis(), VALIDATION_INTERVAL_MILLIS);
+    context.setConnectionValid(false, System.currentTimeMillis());
 
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(expectedFailureCount, context.getFailureCount());
@@ -100,13 +100,13 @@ class MonitorConnectionContextTest {
 
     // Simulate monitor loop that reports invalid connection for 6 times with interval 50 msec
     for (int i = 0; i < 6; i++) {
-      context.setConnectionValid(false, currentTimeMillis, VALIDATION_INTERVAL_MILLIS);
+      context.setConnectionValid(false, currentTimeMillis);
       Assertions.assertFalse(context.isNodeUnhealthy());
 
       currentTimeMillis += VALIDATION_INTERVAL_MILLIS;
     }
 
-    context.setConnectionValid(false, currentTimeMillis, VALIDATION_INTERVAL_MILLIS);
+    context.setConnectionValid(false, currentTimeMillis);
     Assertions.assertTrue(context.isNodeUnhealthy());
   }
 }


### PR DESCRIPTION
### Summary

Add missing Javadoc reported by the checkstyle plugin.
Will selectively add more Javadoc in important/complex code paths in a different PR.

### Extra Fixes

- Remove unused parameter in `MonitorConnectionContext`
- Fix a missing change lost during rebase.

### Additional Reviewers

@sergiyv-bitquill 
@ColinKYuen 
@matthewh-BQ 