### PR TITLE
fix: Integration test

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -1194,6 +1194,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       dealWithInvocationException(e);
     } catch (IllegalStateException e) {
       dealWithIllegalStateException(e);
+    } catch (Exception e) {
+      dealWithOriginalException(e, null);
     }
 
     performSpecialMethodHandlingIfRequired(args, methodName);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -175,6 +175,8 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
           dealWithInvocationException(e);
         } catch (IllegalStateException e) {
           dealWithIllegalStateException(e);
+        } catch (Exception e) {
+          dealWithOriginalException(e, null);
         }
 
         return result;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -28,6 +28,7 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.log.Log;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 
 public class DefaultConnectionPlugin implements IConnectionPlugin {
@@ -46,6 +47,15 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     try {
       return executeSqlFunc.call();
+    } catch (InvocationTargetException invocationTargetException) {
+      Throwable targetException = invocationTargetException.getTargetException();
+      this.logger.logTrace(
+          String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ",
+              methodInvokeOn.getName(), methodName), targetException);
+      if (targetException instanceof Error) {
+        throw (Error) targetException;
+      }
+      throw (Exception) targetException;
     } catch (Exception ex) {
       this.logger.logTrace(
           String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ", methodInvokeOn.getName(), methodName), ex);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -28,7 +28,6 @@ package com.mysql.cj.jdbc.ha.ca.plugins;
 
 import com.mysql.cj.log.Log;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 
 public class DefaultConnectionPlugin implements IConnectionPlugin {
@@ -47,7 +46,7 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     try {
       return executeSqlFunc.call();
-    }  catch (Exception ex) {
+    } catch (Exception ex) {
       this.logger.logTrace(
           String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ", methodInvokeOn.getName(), methodName), ex);
       throw ex;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultConnectionPlugin.java
@@ -47,15 +47,7 @@ public class DefaultConnectionPlugin implements IConnectionPlugin {
   public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc) throws Exception {
     try {
       return executeSqlFunc.call();
-    } catch (InvocationTargetException invocationTargetException) {
-      Throwable targetException = invocationTargetException.getTargetException();
-      this.logger.logTrace(
-              String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ", methodInvokeOn.getName(), methodName), targetException);
-      if (targetException instanceof Error) {
-        throw (Error) targetException;
-      }
-      throw (Exception) targetException;
-    } catch (Exception ex) {
+    }  catch (Exception ex) {
       this.logger.logTrace(
           String.format("[DefaultConnectionPlugin.execute]: method=%s.%s, exception: ", methodInvokeOn.getName(), methodName), ex);
       throw ex;


### PR DESCRIPTION
### Summary

Fixes failover integration test failures

### Description

Issue was caused by catching `InvocationTargetException` inside `DefaultConnectionPlugin` and then casting it to a generic `Exception`. This caused issues when the driver was trying to intercept the exception but was not able to get the correct information due to the cast.

### Additional Reviewers

@karenc-bq @sergiyv-bitquill 