### PR TITLE
Remove JBoss dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -235,7 +235,6 @@ dependencies {
     implementation("org.javassist:javassist:3.28.0-GA")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
-    runtimeOnly("org.javassist:javassist:3.28.0-GA")
     compileOnly("org.ajoberstar.grgit:grgit-gradle:4.1.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,10 +232,10 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-rds:1.11.875")
     implementation("com.google.protobuf:protobuf-java:3.11.4")
     implementation("com.mchange:c3p0:0.9.5.5")
-    implementation("org.jboss.jbossas:jboss-as-connector:6.1.0.Final")
+    implementation("org.javassist:javassist:3.28.0-GA")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
-    runtimeOnly("org.javassist:javassist:3.27.0-GA")
+    runtimeOnly("org.javassist:javassist:3.28.0-GA")
     compileOnly("org.ajoberstar.grgit:grgit-gradle:4.1.0")
 }
 

--- a/src/test/java/com/mysql/cj/jdbc/NonRegisteringDriverTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/NonRegisteringDriverTest.java
@@ -37,17 +37,12 @@ import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/mysql/cj/jdbc/SQLXMLTests.java
+++ b/src/test/java/com/mysql/cj/jdbc/SQLXMLTests.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
### Summary

Remove outdated JBoss dependency with `org.javassist:javassist`
Build scan: https://scans.gradle.com/s/chrjkbwpxpr3k
![image](https://user-images.githubusercontent.com/64801825/145885323-2a9f5cfe-dfd1-4154-a708-2ebad0673510.png)

### Description

- Replace `jboss-as-connector` dependency from 2011 with a more specific and up-to-date dependency `javassist`
- Fix Assertion imports in tests

### Additional Reviewers

@matthewh-BQ 
@sergiyv-bitquill 
@ColinKYuen 