### PR TITLE
fix: NetworkFailuresFailoverIntegrationTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,12 +192,6 @@ tasks.named<Test>("test") {
 
     passProperty("com.mysql.cj.testsuite.url")
     passProperty("com.mysql.cj.testsuite.url.openssl")
-
-    passProperty("com.mysql.cj.testsuite.failover.networkFailures.clusterEndpointBase")
-    passProperty("com.mysql.cj.testsuite.failover.networkFailures.clusterName")
-    passProperty("com.mysql.cj.testsuite.failover.networkFailures.database")
-    passProperty("com.mysql.cj.testsuite.failover.networkFailures.user")
-    passProperty("com.mysql.cj.testsuite.failover.networkFailures.password")
 }
 
 tasks.named<Checkstyle>("checkstyleMain") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,13 +52,6 @@ systemProp.user.timezone=Africa/Lagos
 systemProp.com.mysql.cj.testsuite.url=jdbc:mysql://localhost:3306/test?serverTimezone=Africa/Lagos&user=root&password=root
 systemProp.com.mysql.cj.testsuite.url.openssl=jdbc:mysql://localhost:3307/test?serverTimezone=Africa/Lagos&user=root&password=root
 
-# These values need to be manually entered prior to running NetworkFailuresFailoverIntegrationTests.
-systemProp.com.mysql.cj.testsuite.failover.networkFailures.clusterEndpointBase=
-systemProp.com.mysql.cj.testsuite.failover.networkFailures.clusterName=
-systemProp.com.mysql.cj.testsuite.failover.networkFailures.database=
-systemProp.com.mysql.cj.testsuite.failover.networkFailures.user=
-systemProp.com.mysql.cj.testsuite.failover.networkFailures.password=
-
 signing.keyId=
 signing.password=
 signing.secretKeyRingFile=

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -752,7 +752,6 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     synchronized (this.lockObject) {
       if (this.isClosed && this.closedExplicitly) {
         this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.14"));
-        releasePluginManager();
         return;
       }
 
@@ -982,7 +981,6 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     }
 
     this.log.logError(message);
-    releasePluginManager();
     throw new SQLException(
         message,
         MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE);

--- a/src/test/java/testsuite/failover/NetworkFailuresFailoverIntegrationTest.java
+++ b/src/test/java/testsuite/failover/NetworkFailuresFailoverIntegrationTest.java
@@ -71,9 +71,10 @@ public class NetworkFailuresFailoverIntegrationTest {
   private final Log log;
 
   // Examples below refers to standard Aurora RDS endpoint: "XXX.cluster-YYY.ZZZ.rds.amazonaws.com"
-  private static final String DB_CONN_HOST_BASE = System.getProperty("com.mysql.cj.testsuite.failover.networkFailures.clusterEndpointBase"); // "YYY.ZZZ.rds.amazonaws.com"
-  private static final String DB_CLUSTER_NAME = System.getProperty("com.mysql.cj.testsuite.failover.networkFailures.clusterName"); // "XXX"
-  private static final String DB_DATABASE = System.getProperty("com.mysql.cj.testsuite.failover.networkFailures.database");
+  private static final String DB_CONN_STR_SUFFIX = System.getenv("DB_CONN_STR_SUFFIX"); // "YYY.ZZZ.rds.amazonaws.com"
+  private static final String DB_CONN_HOST_BASE = DB_CONN_STR_SUFFIX.startsWith(".") ? DB_CONN_STR_SUFFIX.substring(1) : DB_CONN_STR_SUFFIX; // "YYY.ZZZ.rds.amazonaws.com"
+  private static final String DB_CLUSTER_NAME = System.getenv("TEST_DB_CLUSTER_IDENTIFIER"); // "XXX"
+  private static final String DB_DATABASE = "test";
 
   private static final String DB_INSTANCE_1 = "mysql-instance-1";
   private static final String DB_INSTANCE_2 = "mysql-instance-2";
@@ -90,8 +91,8 @@ public class NetworkFailuresFailoverIntegrationTest {
   private static final String DB_CONN_CLUSTER_RO = "jdbc:mysql:aws://" + DB_HOST_CLUSTER_RO + "/" + DB_DATABASE;
   private static final String DB_CONN_INSTANCE_PATTERN = "jdbc:mysql:aws://" + DB_HOST_INSTANCE_PATTERN + "/" + DB_DATABASE;
 
-  private static final String DB_USER = System.getProperty("com.mysql.cj.testsuite.failover.networkFailures.user");
-  private static final String DB_PASS = System.getProperty("com.mysql.cj.testsuite.failover.networkFailures.password");
+  private static final String DB_USER = System.getenv("TEST_USERNAME");
+  private static final String DB_PASS = System.getenv("TEST_PASSWORD");
 
   public NetworkFailuresFailoverIntegrationTest() throws SQLException {
     DriverManager.registerDriver(new com.mysql.cj.jdbc.Driver());
@@ -112,6 +113,7 @@ public class NetworkFailuresFailoverIntegrationTest {
     props.setProperty(PropertyKey.socketFactory.getKeyName(), testsuite.UnreliableSocketFactory.class.getName());
     props.setProperty(PropertyKey.socketTimeout.getKeyName(), "1000");
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
+    props.setProperty(PropertyKey.failoverTimeoutMs.getKeyName(), "10000");
     final Connection testConnection = DriverManager.getConnection(DB_CONN_CLUSTER, props);
 
     String currentWriter = selectSingleRow(testConnection, "SELECT @@aurora_server_id");


### PR DESCRIPTION
### Summary
Fix Network Failures Failover Integration Test 

### Description
Related Ticket: [389](https://bitquill.atlassian.net/browse/RDS-389)

- Updated params for db connection
- Removed two releaseResources() causing NPE
- Reduced `failoverTimeoutMs` for `test_1_LostConnectionToWriter` to 10,000 (10s) rather than using default of 300,000 (5m). This was causing it to ""hang"".
Removed the following as they are no longer used
- systemProp.com.mysql.cj.testsuite.failover.networkFailures.clusterEndpointBase
- systemProp.com.mysql.cj.testsuite.failover.networkFailures.clusterName
- systemProp.com.mysql.cj.testsuite.failover.networkFailures.database
- systemProp.com.mysql.cj.testsuite.failover.networkFailures.user
- systemProp.com.mysql.cj.testsuite.failover.networkFailures.password

### Additional Reviewers

@karenc-bq @sergiyv-bitquill @matthewh-BQ 