### PR TITLE
Update build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,26 +70,25 @@ repositories {
     maven {
         url = uri("https://repository.jboss.org/")
     }
-    jcenter()
 }
 
 tasks.register<JavaExec>("commonChecks") {
     classpath = sourceSets["main"].runtimeClasspath
-    main = "instrumentation.CommonChecks"
+    mainClass.set("instrumentation.CommonChecks")
     args = listOf("${buildDir}/classes/java/main", "false")
     dependsOn("classes")
 }
 
 tasks.register<JavaExec>("translateExceptions") {
     classpath = sourceSets["main"].runtimeClasspath
-    main = "instrumentation.TranslateExceptions"
+    mainClass.set("instrumentation.TranslateExceptions")
     args = listOf("${buildDir}/classes/java/main", "false")
     dependsOn("commonChecks")
 }
 
 tasks.register<JavaExec>("addMethods") {
     classpath = sourceSets["main"].runtimeClasspath
-    main = "instrumentation.AddMethods"
+    mainClass.set("instrumentation.AddMethods")
     args = listOf("${buildDir}/classes/java/main", "false")
     dependsOn("translateExceptions")
 }


### PR DESCRIPTION
### Summary

Update deprecated methods in the build file

### Description

Some methods are deprecated in Gradle 7+

### Additional Reviewers

@matthewh-BQ 
@ColinKYuen 
@sergiyv-bitquill 