### PR TITLE
refactor: run monitoring threads as daemon threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,6 @@ To learn how to write custom plugins, refer to examples located inside [Custom P
 | --------------- |:---------------:|:-------------:|:------------ | ------------- |
 |`connectionPluginFactories` | String | No | String of fully-qualified class name of plugin factories. <br/><br/>Each factory in the string should be comma-separated `,`<br/><br/>**NOTE: The order of factories declared matters.**  <br/><br/>Example: `customplugins.MethodCountConnectionPluginFactory`, `customplugins.ExecutionTimeConnectionPluginFactory,com.mysql.cj.jdbc.ha.ca.plugins.NodeMonitoringConnectionPluginFactory` | `com.mysql.cj.jdbc.ha.ca.plugins.NodeMonitoringConnectionPluginFactory` |
 
->### :warning: Warnings About Resource Usage in Connection Plugin Manager
->If the application is unable to close, it may be due to connection plugin manager not being able to release resources properly. User can manually release resources by calling `software.aws.rds.jdbc.mysql.Driver.releasePluginManagers()`.
-
 ### Enhanced Failure Monitoring
 <div style="text-align:center"><img src="./docs/files/images/enhanced_failure_monitoring_diagram.png" /></div>
 The figure above shows a simplified workflow of Enhanced Failure Monitoring. Enhanced Failure Monitoring, is a connection plugin implemented by using a monitor thread. The monitor will periodically check the connected database node's health. In the case of the database node showing up as unhealthy, the query will be retried with a new database node and the monitor is restarted. 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/ConnectionPluginManager.java
@@ -33,9 +33,7 @@ import com.mysql.cj.log.Log;
 import com.mysql.cj.util.StringUtils;
 import com.mysql.cj.util.Util;
 
-import java.util.Queue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * This class creates and handles a chain of {@link IConnectionPlugin} for each connection.
@@ -47,16 +45,11 @@ public class ConnectionPluginManager {
 
   protected static final String DEFAULT_PLUGIN_FACTORIES =
       NodeMonitoringConnectionPluginFactory.class.getName();
-  protected static final Queue<ConnectionPluginManager> instances = new ConcurrentLinkedQueue<>();
 
   protected Log logger;
   protected PropertySet propertySet = null;
   protected IConnectionPlugin headPlugin = null;
   ClusterAwareConnectionProxy proxy;
-
-  static {
-    Runtime.getRuntime().addShutdownHook(new Thread(ConnectionPluginManager::releaseAllResources));
-  }
 
   public ConnectionPluginManager(Log logger) {
     if (logger == null) {
@@ -79,7 +72,6 @@ public class ConnectionPluginManager {
    * @param propertySet The configuration of the connection.
    */
   public void init(ClusterAwareConnectionProxy proxy, PropertySet propertySet) {
-    instances.add(this);
     this.proxy = proxy;
     this.propertySet = propertySet;
 
@@ -141,15 +133,7 @@ public class ConnectionPluginManager {
    * a single connection.
    */
   public void releaseResources() {
-    instances.remove(this);
     this.logger.logTrace("[ConnectionPluginManager.releaseResources]");
     this.headPlugin.releaseResources();
-  }
-
-  /**
-   * Release all dangling resources for all connection plugin managers.
-   */
-  public static void releaseAllResources() {
-    instances.forEach(ConnectionPluginManager::releaseResources);
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -35,7 +35,9 @@ import com.mysql.cj.jdbc.ha.ca.BasicConnectionProvider;
 import com.mysql.cj.log.Log;
 
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * This class handles the creation and clean up of monitoring threads to servers with one
@@ -56,7 +58,12 @@ public class DefaultMonitorService implements IMonitorService {
             propertySet.getIntegerProperty(PropertyKey.monitorDisposalTime).getValue(),
             monitorService,
             logger),
-        Executors::newCachedThreadPool,
+        () -> Executors.newCachedThreadPool(r -> {
+          final Thread monitoringThread = new Thread(r);
+          monitoringThread.setDaemon(true);
+          monitoringThread.setPriority(Thread.MAX_PRIORITY);
+          return monitoringThread;
+        }),
         logger
     );
   }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -61,7 +61,6 @@ public class DefaultMonitorService implements IMonitorService {
         () -> Executors.newCachedThreadPool(r -> {
           final Thread monitoringThread = new Thread(r);
           monitoringThread.setDaemon(true);
-          monitoringThread.setPriority(Thread.NORM_PRIORITY);
           return monitoringThread;
         }),
         logger

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/plugins/DefaultMonitorService.java
@@ -61,7 +61,7 @@ public class DefaultMonitorService implements IMonitorService {
         () -> Executors.newCachedThreadPool(r -> {
           final Thread monitoringThread = new Thread(r);
           monitoringThread.setDaemon(true);
-          monitoringThread.setPriority(Thread.MAX_PRIORITY);
+          monitoringThread.setPriority(Thread.NORM_PRIORITY);
           return monitoringThread;
         }),
         logger

--- a/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
+++ b/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
@@ -31,7 +31,6 @@
 package software.aws.rds.jdbc.mysql;
 
 import com.mysql.cj.jdbc.NonRegisteringDriver;
-import com.mysql.cj.jdbc.ha.ca.plugins.ConnectionPluginManager;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -86,12 +85,5 @@ public class Driver extends NonRegisteringDriver {
    */
   public Driver() throws SQLException {
     // Required for Class.forName().newInstance()
-  }
-
-  /**
-   * Release all resources currently held up by {@link ConnectionPluginManager}.
-   */
-  public static void releasePluginManagers() {
-    ConnectionPluginManager.releaseAllResources();
   }
 }


### PR DESCRIPTION
### Summary

Use daemon threads to monitor failure.

### Performance With **~7%** Server CPU Usage
#### Query 1
|           | Average Execution Time (s) |        | Warmup Time vs. Community |
|-----------|----------------------------|--------|---------------------------|
|           | No Warmup                  | Warmup |                           |
| Community | 0.022                      | 0.019  | 0.00%                     |
| Introspection  | 0.04                       | 0.037  | 94.74%                    |
| Daemon    | 0.03                     | 0.027   | 42.11%                   |

#### Query 2
|           | Average Execution Time (s) |        | Warmup Time vs. Community |
|-----------|----------------------------|--------|---------------------------|
|           | No Warmup                  | Warmup |                           |
| Community | 5.172                      | 4.904  | 0.00%                     |
| Introspection  | 6.407                      | 7.158  | 45.96%                    |
| Daemon    | 6.252                      | 4.798 | -2.16%                    |

### Additional Reviewers

@matthewh-BQ 
@ColinKYuen 
@sergiyv-bitquill 