### PR TITLE
Propagate SQL exception from queryTopology

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -170,7 +170,8 @@ public class AuroraTopologyService
    *     Returns an empty list if topology isn't available or is invalid (doesn't contain a writer).
    */
   @Override
-  public List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate) {
+  public List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate)
+      throws SQLException {
     ClusterTopologyInfo clusterTopologyInfo = topologyCache.get(this.clusterId);
 
     if (clusterTopologyInfo == null
@@ -203,7 +204,7 @@ public class AuroraTopologyService
    * @param conn A connection to database to fetch the latest topology.
    * @return Cluster topology details.
    */
-  protected ClusterTopologyInfo queryForTopology(JdbcConnection conn) {
+  protected ClusterTopologyInfo queryForTopology(JdbcConnection conn) throws SQLException {
     long startTimeMs = this.gatherPerfMetrics ? System.currentTimeMillis() : 0;
 
     ClusterTopologyInfo topologyInfo = null;
@@ -211,22 +212,21 @@ public class AuroraTopologyService
       try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
         topologyInfo = processQueryResults(resultSet);
       }
-    } catch (SQLException e) {
-      // ignore
-    }
 
-    if (this.gatherPerfMetrics) {
-      long currentTimeMs = System.currentTimeMillis();
-      this.queryTopologyMetrics.registerQueryExecutionTime(currentTimeMs - startTimeMs);
+      return topologyInfo;
+      // return topologyInfo != null ? topologyInfo
+      //     : new ClusterTopologyInfo(
+      //         new ArrayList<>(),
+      //         new HashSet<>(),
+      //         null,
+      //         Instant.now(),
+      //         false);
+     } finally {
+      if (this.gatherPerfMetrics) {
+        long currentTimeMs = System.currentTimeMillis();
+        this.queryTopologyMetrics.registerQueryExecutionTime(currentTimeMs - startTimeMs);
+      }
     }
-
-    return topologyInfo != null ? topologyInfo
-        : new ClusterTopologyInfo(
-            new ArrayList<>(),
-            new HashSet<>(),
-            null,
-            Instant.now(),
-            false);
   }
 
   /**

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -207,20 +207,13 @@ public class AuroraTopologyService
   protected ClusterTopologyInfo queryForTopology(JdbcConnection conn) throws SQLException {
     long startTimeMs = this.gatherPerfMetrics ? System.currentTimeMillis() : 0;
 
-    ClusterTopologyInfo topologyInfo = null;
+    ClusterTopologyInfo topologyInfo;
     try (Statement stmt = conn.createStatement()) {
       try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
         topologyInfo = processQueryResults(resultSet);
       }
 
       return topologyInfo;
-      // return topologyInfo != null ? topologyInfo
-      //     : new ClusterTopologyInfo(
-      //         new ArrayList<>(),
-      //         new HashSet<>(),
-      //         null,
-      //         Instant.now(),
-      //         false);
      } finally {
       if (this.gatherPerfMetrics) {
         long currentTimeMs = System.currentTimeMillis();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
@@ -298,7 +298,7 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
       this.originalWriterHost = currentHost;
     }
 
-    public WriterFailoverResult call() {
+    public WriterFailoverResult call() throws SQLException {
       log.logTrace(Messages.getString("ClusterAwareWriterFailoverHandler.9"));
 
       try {
@@ -368,7 +368,8 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
      *
      * @return Returns true if successful.
      */
-    private boolean refreshTopologyAndConnectToNewWriter() throws InterruptedException {
+    private boolean refreshTopologyAndConnectToNewWriter()
+        throws InterruptedException, SQLException {
       while (true) {
         List<HostInfo> topology =
             topologyService.getTopology(this.currentReaderConnection, true);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -735,17 +735,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     List<HostInfo> latestTopology =
         this.topologyService.getTopology(connection, forceUpdate);
 
-    if (Util.isNullOrEmpty(latestTopology) || connection.isClosed()) {
-      pickNewConnection();
-      return;
-    }
-
     this.hosts = latestTopology;
-    if (!isConnected()) {
-      pickNewConnection();
-      return;
-    }
-
     updateHostIndex(latestTopology);
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -241,9 +241,9 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
     Object result = null;
 
-    updateTopologyAndConnectIfNeeded(false);
 
     try {
+      updateTopologyAndConnectIfNeeded(false);
       result = this.nextPlugin.execute(methodInvokeOn, methodName, executeSqlFunc, args);
     } catch (IllegalStateException e) {
       dealWithIllegalStateException(e);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ITopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ITopologyService.java
@@ -29,6 +29,7 @@ package com.mysql.cj.jdbc.ha.plugins.failover;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.jdbc.JdbcConnection;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 
@@ -72,7 +73,8 @@ public interface ITopologyService {
    * @return A list of hosts that describes cluster topology. A writer is always at position 0.
    *     Returns an empty list if topology isn't available or is invalid (doesn't contain a writer).
    */
-  List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate);
+  List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate)
+      throws SQLException;
 
   /**
    * Get cached topology.

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -606,7 +606,7 @@ class FailoverConnectionPluginTest {
   }
 
   @BeforeEach
-  void init() {
+  void init() throws SQLException {
     closeable = MockitoAnnotations.openMocks(this);
 
     when(mockTopologyService.getTopology(


### PR DESCRIPTION
### Summary

Propagate SQL exception from queryTopology

### Description

Propagate SQL exception from queryTopology so it can be handled by caller instead of ignoring the exception

### Additional Reviewers

@sergiyv-bitquill 
@ColinKYuen 