### PR TITLE
chore: Workflow manual trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,19 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
-  pull_request_review:
     branches:
       - main
     paths-ignore:
       - '**/*.md'
 
+concurrency:
+  group: environment-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-latest-aurora-run-integration-tests:
-    if: github.event.review.state == 'approved'
     concurrency: IntegrationTests
     name: 'Run Integration Tests'
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Workflow manual trigger

### Description

Workflow can now be manually triggered by going to Actions -> CI -> Run Workflow

### Additional Reviewers

@sergiyv-bitquill @karenc-bq @crystall-bitquill 