### PR TITLE
fix the bug: adjust allowed failure time

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/Monitor.java
@@ -137,15 +137,16 @@ public class Monitor implements IMonitor {
       this.stopped.set(false);
       while (true) {
         if (!this.contexts.isEmpty()) {
-          final long currentTime = this.getCurrentTimeMillis();
-          this.lastContextUsedTimestamp.set(currentTime);
+          final long statusCheckStartTime = this.getCurrentTimeMillis();
+          this.lastContextUsedTimestamp.set(statusCheckStartTime);
 
           final ConnectionStatus status =
               checkConnectionStatus(this.getConnectionCheckIntervalMillis());
 
           for (MonitorConnectionContext monitorContext : this.contexts) {
             monitorContext.updateConnectionStatus(
-                currentTime,
+                statusCheckStartTime,
+                statusCheckStartTime + status.elapsedTime,
                 status.isValid);
           }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContext.java
@@ -157,10 +157,12 @@ public class MonitorConnectionContext {
    * Update whether the connection is still valid if the total elapsed time has passed the
    * grace period.
    *
-   * @param currentTime The time when this method is called.
+   * @param statusCheckStartTime The time when connection status check started in milliseconds.
+   * @param currentTime The time when connection status check ended in milliseconds.
    * @param isValid Whether the connection is valid.
    */
   public void updateConnectionStatus(
+      long statusCheckStartTime,
       long currentTime,
       boolean isValid) {
     if (!this.activeContext) {
@@ -170,7 +172,7 @@ public class MonitorConnectionContext {
     final long totalElapsedTimeMillis = currentTime - this.startMonitorTime;
 
     if (totalElapsedTimeMillis > this.failureDetectionTimeMillis) {
-      this.setConnectionValid(isValid, currentTime);
+      this.setConnectionValid(isValid, statusCheckStartTime, currentTime);
     }
   }
 
@@ -186,21 +188,23 @@ public class MonitorConnectionContext {
    * </ul>
    *
    * @param connectionValid Boolean indicating whether the server is still responsive.
-   * @param currentTime The time when this method is invoked in milliseconds.
+   * @param statusCheckStartTime The time when connection status check started in milliseconds.
+   * @param currentTime The time when connection status check ended in milliseconds.
    */
   void setConnectionValid(
       boolean connectionValid,
+      long statusCheckStartTime,
       long currentTime) {
     if (!connectionValid) {
       this.failureCount++;
 
       if (!this.isInvalidNodeStartTimeDefined()) {
-        this.setInvalidNodeStartTime(currentTime);
+        this.setInvalidNodeStartTime(statusCheckStartTime);
       }
 
       final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
       final long maxInvalidNodeDurationMillis =
-          (long) this.getFailureDetectionIntervalMillis() * Math.max(0, this.getFailureDetectionCount() - 1);
+          (long) this.getFailureDetectionIntervalMillis() * Math.max(0, this.getFailureDetectionCount());
 
       if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
         this.log.logTrace(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContext.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContext.java
@@ -200,7 +200,7 @@ public class MonitorConnectionContext {
 
       final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
       final long maxInvalidNodeDurationMillis =
-          (long) this.getFailureDetectionIntervalMillis() * this.getFailureDetectionCount();
+          (long) this.getFailureDetectionIntervalMillis() * Math.max(0, this.getFailureDetectionCount() - 1);
 
       if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
         this.log.logTrace(

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContextTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContextTest.java
@@ -67,14 +67,16 @@ class MonitorConnectionContextTest {
 
   @Test
   public void test_1_isNodeUnhealthyWithConnection_returnFalse() {
-    context.setConnectionValid(true, System.currentTimeMillis());
+    long currentTimeMillis = System.currentTimeMillis();
+    context.setConnectionValid(true, currentTimeMillis, currentTimeMillis);
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(0, this.context.getFailureCount());
   }
 
   @Test
   public void test_2_isNodeUnhealthyWithInvalidConnection_returnFalse() {
-    context.setConnectionValid(false, System.currentTimeMillis());
+    long currentTimeMillis = System.currentTimeMillis();
+    context.setConnectionValid(false, currentTimeMillis, currentTimeMillis);
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(1, this.context.getFailureCount());
   }
@@ -85,7 +87,8 @@ class MonitorConnectionContextTest {
     context.setFailureCount(FAILURE_DETECTION_COUNT);
     context.resetInvalidNodeStartTime();
 
-    context.setConnectionValid(false, System.currentTimeMillis());
+    long currentTimeMillis = System.currentTimeMillis();
+    context.setConnectionValid(false, currentTimeMillis, currentTimeMillis);
 
     Assertions.assertFalse(context.isNodeUnhealthy());
     Assertions.assertEquals(expectedFailureCount, context.getFailureCount());
@@ -98,15 +101,25 @@ class MonitorConnectionContextTest {
     context.setFailureCount(0);
     context.resetInvalidNodeStartTime();
 
-    // Simulate monitor loop that reports invalid connection for 4 times with interval 50 msec
-    for (int i = 0; i < 4; i++) {
-      context.setConnectionValid(false, currentTimeMillis);
+    // Simulate monitor loop that reports invalid connection for 5 times with interval 50 msec to wait 250 msec in total
+    for (int i = 0; i < 5; i++) {
+      long statusCheckStartTime = currentTimeMillis;
+      long statusCheckEndTime = currentTimeMillis + VALIDATION_INTERVAL_MILLIS;
+
+      context.setConnectionValid(false, statusCheckStartTime, statusCheckEndTime);
       Assertions.assertFalse(context.isNodeUnhealthy());
 
       currentTimeMillis += VALIDATION_INTERVAL_MILLIS;
     }
 
-    context.setConnectionValid(false, currentTimeMillis);
+    // Simulate waiting another 50 msec that makes total waiting time to 300 msec
+    // Expected max waiting time for this context is 300 msec (interval 100 msec, count 3)
+    // So it's expected that this run turns node status to "unhealthy" since we reached max allowed waiting time.
+
+    long statusCheckStartTime = currentTimeMillis;
+    long statusCheckEndTime = currentTimeMillis + VALIDATION_INTERVAL_MILLIS;
+
+    context.setConnectionValid(false, statusCheckStartTime, statusCheckEndTime);
     Assertions.assertTrue(context.isNodeUnhealthy());
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContextTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/MonitorConnectionContextTest.java
@@ -98,8 +98,8 @@ class MonitorConnectionContextTest {
     context.setFailureCount(0);
     context.resetInvalidNodeStartTime();
 
-    // Simulate monitor loop that reports invalid connection for 6 times with interval 50 msec
-    for (int i = 0; i < 6; i++) {
+    // Simulate monitor loop that reports invalid connection for 4 times with interval 50 msec
+    for (int i = 0; i < 4; i++) {
       context.setConnectionValid(false, currentTimeMillis);
       Assertions.assertFalse(context.isNodeUnhealthy());
 

--- a/src/test/java/testsuite/integration/host/AuroraIntegrationContainerTest.java
+++ b/src/test/java/testsuite/integration/host/AuroraIntegrationContainerTest.java
@@ -68,7 +68,6 @@ public class AuroraIntegrationContainerTest {
   private static final String DB_CONN_STR_SUFFIX = System.getenv("DB_CONN_STR_SUFFIX");
   private static final String DB_CONN_PROP = "?enabledTLSProtocols=TLSv1.2";
 
-  // Encounters SSL errors without it on GH Actions
   private static final String TEST_DB_CLUSTER_IDENTIFIER = System.getenv("TEST_DB_CLUSTER_IDENTIFIER");
   private static final String PROXIED_DOMAIN_NAME_SUFFIX = ".proxied";
   private static List<ToxiproxyContainer> proxyContainers = new ArrayList<>();


### PR DESCRIPTION
### Summary

RDS-623: MySQL - JDBC - Verify EFM plugin for number of failures before raising exception.

### Description

EFM plugin waits one failure interval more than expected.

### Additional Reviewers

@ColinKYuen 
@karenc-bq 
@crystall-bitquill 
@matthewh-BQ 