### PR TITLE
Aurora Integration Test Utilities

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,97 +27,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: 'Get Github Action IP'
-        id: ip
-        uses: haythem/public-ip@v1.2
-      - name: 'Add Github Actions IP to Security group'
-        run: |
-          aws ec2 authorize-security-group-ingress \
-            --group-name ${{ secrets.AWS_SG_NAME }} \
-            --protocol all \
-            --port all \
-            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
-          2>&1 > /dev/null;
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: 'Create Test Clusters'
-        run: |
-          aws rds create-db-cluster \
-           --db-cluster-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }} \
-           --master-username ${{ secrets.TEST_USERNAME }} \
-           --master-user-password ${{ secrets.TEST_PASSWORD }} \
-           --source-region ${{ secrets.AWS_DEFAULT_REGION }} \
-           --enable-iam-database-authentication \
-           --engine aurora-mysql \
-           --storage-encrypted \
-          2>&1 > /dev/null;
-      - name: 'Add 5 Test Instances'
-        run: |
-          for i in {1..5}; \
-            do \
-              aws rds create-db-instance \
-                --db-cluster-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }} \
-                --db-instance-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }}-i-$i \
-                --db-instance-class db.r5.large \
-                --engine aurora-mysql \
-                --publicly-accessible \
-            2>&1 > /dev/null; \
-          done;
-      - name: 'Wait for clusters to be up'
-        run: |
-          for i in {1..5}; \
-            do \
-              aws rds wait \
-                db-instance-available \
-                --db-instance-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }}-i-$i \
-            2>&1 > /dev/null; \
-          done;
       - name: 'Run Integration Tests'
         run: |
           ./gradlew --no-parallel --no-daemon test-integration-docker
         env:
-          DB_CONN_STR_SUFFIX: ${{ secrets.DB_CONN_STR_SUFFIX }}
           TEST_DB_CLUSTER_IDENTIFIER: ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }}
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-      - name: 'Delete Instances'
-        if: always()
-        run: |
-          for i in {1..5}; \
-            do \
-            aws rds delete-db-instance \
-              --db-instance-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }}-i-$i \
-              --skip-final-snapshot \
-            2>&1 > /dev/null; \
-          done;
-      - name: 'Delete Cluster'
-        if: always()
-        run: |
-          aws rds delete-db-cluster \
-            --db-cluster-identifier ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }} \
-            --skip-final-snapshot \
-          2>&1 > /dev/null;
-      - name: 'Remove Github Action IP'
-        if: always()
-        run: |
-          aws ec2 revoke-security-group-ingress \
-            --group-name ${{ secrets.AWS_SG_NAME }} \
-            --protocol all \
-            --port all \
-            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
-          2>&1 > /dev/null;
-        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: 'Archive junit results'
         if: always()
         uses: actions/upload-artifact@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -214,6 +214,7 @@ tasks.withType<Checkstyle>().configureEach {
 dependencies {
     testImplementation("org.apache.commons:commons-dbcp2:2.8.0")
     testImplementation("com.amazonaws:aws-java-sdk-rds:1.12.128")
+    testImplementation("com.amazonaws:aws-java-sdk-ec2:1.12.148")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")

--- a/src/test/java/testsuite/integration/host/AuroraIntegrationContainerTest.java
+++ b/src/test/java/testsuite/integration/host/AuroraIntegrationContainerTest.java
@@ -141,11 +141,7 @@ public class AuroraIntegrationContainerTest {
   @AfterAll
   static void tearDown() {
     // Comment below out if you don't want to delete cluster after tests finishes
-    if (StringUtils.isNullOrEmpty(TEST_DB_CLUSTER_IDENTIFIER)) {
-      auroraUtil.deleteCluster();
-    } else {
-      auroraUtil.deleteCluster(TEST_DB_CLUSTER_IDENTIFIER);
-    }
+    auroraUtil.deleteCluster(TEST_DB_CLUSTER_IDENTIFIER);
 
     auroraUtil.ec2DeauthorizesIP(runnerIP);
     for (ToxiproxyContainer proxy : proxyContainers) {

--- a/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
+++ b/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
@@ -1,0 +1,166 @@
+package testsuite.integration.utility;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.AmazonRDSClientBuilder;
+import com.amazonaws.services.rds.model.CreateDBClusterRequest;
+import com.amazonaws.services.rds.model.CreateDBInstanceRequest;
+import com.amazonaws.services.rds.model.DeleteDBClusterRequest;
+import com.amazonaws.services.rds.model.DeleteDBInstanceRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.Filter;
+import com.amazonaws.services.rds.waiters.AmazonRDSWaiters;
+import com.amazonaws.waiters.NoOpWaiterHandler;
+import com.amazonaws.waiters.Waiter;
+import com.amazonaws.waiters.WaiterHandler;
+import com.amazonaws.waiters.WaiterParameters;
+import com.amazonaws.waiters.WaiterTimedOutException;
+import com.amazonaws.waiters.WaiterUnrecoverableException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Creates and destroys AWS RDS Cluster and Instances
+ * By default, AWS Credentials will be loaded in from environment variables
+ * To load credentials with other methods, use AuroraTestUtility(String region, AWSCredentialsProvider credentials)
+ *
+ * Environment variables to include
+ *     Required
+ *     - AWS_ACCESS_KEY
+ *     - AWS_SECRET_KEY
+ */
+public class AuroraTestUtility {
+    // Default values
+    private static String dbUsername = "my_test_username";
+    private static String dbPassword = "my_test_password";
+    private static String dbIdentifier = "my-identifier-3";
+    private static String dbEngine = "aurora-mysql";
+    private static String dbInstanceClass = "db.r5.large";
+    private static String dbRegion = "us-east-1";
+    private static int numOfInstances = 5;
+
+    private static AmazonRDS rdsClient = null;
+
+    /**
+     * Creates an AmazonRDS Client using AWS Credentials from environment variables
+     * Required Environment Variables
+     *  - AWS_ACCESS_KEY
+     *  - AWS_SECRET_KEY
+     */
+    public AuroraTestUtility() {
+        rdsClient = AmazonRDSClientBuilder
+            .standard()
+            .withRegion(dbRegion)
+            .withCredentials(new EnvironmentVariableCredentialsProvider())
+            .build();
+    }
+
+    public AuroraTestUtility(String region) {
+        dbRegion = region;
+
+        rdsClient = AmazonRDSClientBuilder
+            .standard()
+            .withRegion(dbRegion)
+            .withCredentials(new EnvironmentVariableCredentialsProvider())
+            .build();
+    }
+
+    public AuroraTestUtility(String region, AWSCredentialsProvider credentials) {
+        dbRegion = region;
+
+        rdsClient = AmazonRDSClientBuilder
+            .standard()
+            .withRegion(dbRegion)
+            .withCredentials(credentials)
+            .build();
+    }
+
+    public String initCluster(String username, String password, String identifier, String engine, String instanceClass, String region, int instances)
+        throws InterruptedException {
+        dbUsername = username;
+        dbPassword = password;
+        dbIdentifier = identifier;
+        dbEngine = engine;
+        dbInstanceClass = instanceClass;
+        dbRegion = region;
+        numOfInstances = instances;
+        return initCluster();
+    }
+
+    public String initCluster(String username, String password, String identifier)
+        throws InterruptedException {
+        dbUsername = username;
+        dbPassword = password;
+        dbIdentifier = identifier;
+        return initCluster();
+    }
+
+    public String initCluster() throws InterruptedException {
+        // Create Cluster
+        CreateDBClusterRequest dbClusterRequest = new CreateDBClusterRequest()
+            .withDBClusterIdentifier(dbIdentifier)
+            .withMasterUsername(dbUsername)
+            .withMasterUserPassword(dbPassword)
+            .withSourceRegion(dbRegion)
+            .withEnableIAMDatabaseAuthentication(true)
+            .withEngine(dbEngine)
+            .withStorageEncrypted(true);
+
+        rdsClient.createDBCluster(dbClusterRequest);
+
+        // Create Instances
+        CreateDBInstanceRequest dbInstanceRequest = new CreateDBInstanceRequest()
+            .withDBClusterIdentifier(dbIdentifier)
+            .withDBInstanceClass(dbInstanceClass)
+            .withEngine(dbEngine)
+            .withPubliclyAccessible(true);
+
+        for (int i = 1; i <= numOfInstances; i++) {
+            rdsClient.createDBInstance(dbInstanceRequest.withDBInstanceIdentifier(dbIdentifier + "-" + i));
+        }
+
+        // Wait for all instances to be up
+        AmazonRDSWaiters waiter = new AmazonRDSWaiters(rdsClient);
+        DescribeDBInstancesRequest dbInstancesRequest = new DescribeDBInstancesRequest()
+            .withFilters(new Filter().withName("db-cluster-id").withValues(dbIdentifier));
+        Waiter<DescribeDBInstancesRequest> instancesRequestWaiter = waiter
+            .dBInstanceAvailable();
+        Future<Void> future = instancesRequestWaiter.runAsync(new WaiterParameters<>(dbInstancesRequest), new NoOpWaiterHandler());
+        try {
+            future.get(30, TimeUnit.MINUTES);
+        } catch (WaiterUnrecoverableException | WaiterTimedOutException | TimeoutException | ExecutionException exception) {
+            teardown();
+            throw new InterruptedException("Unable to start AWS RDS Cluster & Instances after waiting for 30 minutes");
+        }
+
+        DescribeDBInstancesResult dbInstancesResult = rdsClient.describeDBInstances(dbInstancesRequest);
+        String suffix = dbInstancesResult.getDBInstances().get(0).getEndpoint().getAddress();
+        suffix = suffix.substring(suffix.indexOf('.'));
+        return suffix;
+    }
+
+    public void teardown() {
+        if (rdsClient == null) return;
+
+        // Tear down instances
+        DeleteDBInstanceRequest dbDeleteInstanceRequest = new DeleteDBInstanceRequest()
+            .withSkipFinalSnapshot(true);
+
+        for (int i = 1; i <= numOfInstances; i++) {
+            rdsClient.deleteDBInstance(dbDeleteInstanceRequest.withDBInstanceIdentifier(dbIdentifier + "-" + i));
+        }
+
+        // Tear down cluster
+        DeleteDBClusterRequest dbDeleteClusterRequest = new DeleteDBClusterRequest()
+            .withSkipFinalSnapshot(true)
+            .withDBClusterIdentifier(dbIdentifier);
+
+        rdsClient.deleteDBCluster(dbDeleteClusterRequest);
+    }
+}

--- a/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
+++ b/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
@@ -170,7 +170,7 @@ public class AuroraTestUtility {
      */
     public String createCluster() throws InterruptedException {
         // Create Cluster
-        CreateDBClusterRequest dbClusterRequest = new CreateDBClusterRequest()
+        final CreateDBClusterRequest dbClusterRequest = new CreateDBClusterRequest()
             .withDBClusterIdentifier(dbIdentifier)
             .withMasterUsername(dbUsername)
             .withMasterUserPassword(dbPassword)
@@ -182,7 +182,7 @@ public class AuroraTestUtility {
         rdsClient.createDBCluster(dbClusterRequest);
 
         // Create Instances
-        CreateDBInstanceRequest dbInstanceRequest = new CreateDBInstanceRequest()
+        final CreateDBInstanceRequest dbInstanceRequest = new CreateDBInstanceRequest()
             .withDBClusterIdentifier(dbIdentifier)
             .withDBInstanceClass(dbInstanceClass)
             .withEngine(dbEngine)
@@ -193,12 +193,12 @@ public class AuroraTestUtility {
         }
 
         // Wait for all instances to be up
-        AmazonRDSWaiters waiter = new AmazonRDSWaiters(rdsClient);
-        DescribeDBInstancesRequest dbInstancesRequest = new DescribeDBInstancesRequest()
+        final AmazonRDSWaiters waiter = new AmazonRDSWaiters(rdsClient);
+        final DescribeDBInstancesRequest dbInstancesRequest = new DescribeDBInstancesRequest()
             .withFilters(new Filter().withName("db-cluster-id").withValues(dbIdentifier));
-        Waiter<DescribeDBInstancesRequest> instancesRequestWaiter = waiter
+        final Waiter<DescribeDBInstancesRequest> instancesRequestWaiter = waiter
             .dBInstanceAvailable();
-        Future<Void> future = instancesRequestWaiter.runAsync(new WaiterParameters<>(dbInstancesRequest), new NoOpWaiterHandler());
+        final Future<Void> future = instancesRequestWaiter.runAsync(new WaiterParameters<>(dbInstancesRequest), new NoOpWaiterHandler());
         try {
             future.get(30, TimeUnit.MINUTES);
         } catch (WaiterUnrecoverableException | WaiterTimedOutException | TimeoutException | ExecutionException exception) {
@@ -206,8 +206,8 @@ public class AuroraTestUtility {
             throw new InterruptedException("Unable to start AWS RDS Cluster & Instances after waiting for 30 minutes");
         }
 
-        DescribeDBInstancesResult dbInstancesResult = rdsClient.describeDBInstances(dbInstancesRequest);
-        String endpoint = dbInstancesResult.getDBInstances().get(0).getEndpoint().getAddress();
+        final DescribeDBInstancesResult dbInstancesResult = rdsClient.describeDBInstances(dbInstancesRequest);
+        final String endpoint = dbInstancesResult.getDBInstances().get(0).getEndpoint().getAddress();
         return endpoint.substring(endpoint.indexOf('.') + 1);
     }
 
@@ -230,13 +230,13 @@ public class AuroraTestUtility {
     }
 
     /**
-     * Adds IP to EC2 Security groups for RDS access.
+     * Authorizes IP to EC2 Security groups for RDS access.
      */
-    public void ec2AddIP(String ipAddress) {
+    public void ec2AuthorizeIP(String ipAddress) {
         if (StringUtils.isNullOrEmpty(ipAddress)) {
             return;
         }
-        AuthorizeSecurityGroupIngressRequest authRequest = new AuthorizeSecurityGroupIngressRequest()
+        final AuthorizeSecurityGroupIngressRequest authRequest = new AuthorizeSecurityGroupIngressRequest()
             .withGroupName(dbSecGroup)
             .withCidrIp(ipAddress + "/32")
             .withIpProtocol("-1") // All protocols
@@ -253,14 +253,14 @@ public class AuroraTestUtility {
     }
 
     /**
-     * Removes current runner's public IP from EC2 Security groups.
+     * De-authorizes IP from EC2 Security groups.
      * @throws UnknownHostException
      */
-    public void ec2RemoveIP(String ipAddress) {
+    public void ec2DeauthorizesIP(String ipAddress) {
         if (StringUtils.isNullOrEmpty(ipAddress)) {
             return;
         }
-        RevokeSecurityGroupIngressRequest revokeRequest = new RevokeSecurityGroupIngressRequest()
+        final RevokeSecurityGroupIngressRequest revokeRequest = new RevokeSecurityGroupIngressRequest()
             .withGroupName(dbSecGroup)
             .withCidrIp(ipAddress + "/32")
             .withIpProtocol("-1") // All protocols
@@ -288,7 +288,7 @@ public class AuroraTestUtility {
      */
     public void deleteCluster() {
         // Tear down instances
-        DeleteDBInstanceRequest dbDeleteInstanceRequest = new DeleteDBInstanceRequest()
+        final DeleteDBInstanceRequest dbDeleteInstanceRequest = new DeleteDBInstanceRequest()
             .withSkipFinalSnapshot(true);
 
         for (int i = 1; i <= numOfInstances; i++) {
@@ -296,7 +296,7 @@ public class AuroraTestUtility {
         }
 
         // Tear down cluster
-        DeleteDBClusterRequest dbDeleteClusterRequest = new DeleteDBClusterRequest()
+        final DeleteDBClusterRequest dbDeleteClusterRequest = new DeleteDBClusterRequest()
             .withSkipFinalSnapshot(true)
             .withDBClusterIdentifier(dbIdentifier);
 


### PR DESCRIPTION
### Summary

Aurora Integration Test Utilities

### Description

Creation and destruction of RDS Cluster/Instances are now done using the Java SDK rather than inside GitHub Actions AWS CLI. This includes whitelisting and delisting the current IP address.

### Additional Reviewers

@sergiyv-bitquill @crystall-bitquill @karenc-bq @matthewh-BQ