### PR TITLE
Update host index before updating hosts

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -697,8 +697,8 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     List<HostInfo> latestTopology =
         this.topologyService.getTopology(connection, forceUpdate);
 
-    this.hosts = latestTopology;
     updateHostIndex(latestTopology);
+    this.hosts = latestTopology;
   }
 
   boolean isCurrentConnectionReadOnly() {


### PR DESCRIPTION
### Summary

Update host index before updating hosts

### Description

During failover, the current host index was being updated after updating the hosts. The current host index was incorrect because it used the the latest topology and the old host index rather than the old topology and old host index in the `updateHostIndex(List<HostInfo> latestTopology)` function.

### Additional Reviewers

@sergiyv-bitquill @karenc-bq @ColinKYuen 