### PR TITLE
chore: Allow Forked PR to run CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 name: Pull Request CI
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,7 @@
-name: Main CI
+name: Pull Request CI
 
 on:
-  workflow_dispatch:
-  push:
+  pull_request_target:
     branches:
       - main
 
@@ -11,8 +10,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approve:
+    name: 'Require Approval'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
   ubuntu-latest-aurora-run-integration-tests:
+    needs: [approve]
     concurrency: IntegrationTests
+    environment:
+      name: Integration Forked Pull Request
     name: 'Run Integration Tests'
     runs-on: ubuntu-latest
     steps:

--- a/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
+++ b/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
@@ -578,22 +578,21 @@ public class AuroraMysqlIntegrationTest extends AuroraMysqlIntegrationBaseTest {
     }
   }
 
-  /** Connect to a readonly cluster endpoint and ensure that we are doing a reader failover. */
-  @Disabled // Fails often due to connecting to a writer instance
+  /** Connect to a readonly cluster endpoint and ensure that read-only property is carried over failover. */
   @Test
   public void test_ClusterEndpointReadOnlyFailover() throws SQLException, IOException {
     try (final Connection conn = connectToInstance(MYSQL_RO_CLUSTER_URL + PROXIED_DOMAIN_NAME_SUFFIX, MYSQL_PROXY_PORT)) {
+      assertTrue(conn.isReadOnly());
+
       final String initialConnectionId = queryInstanceId(conn);
-      assertTrue(isDBInstanceReader(initialConnectionId));
 
       final Proxy instanceProxy = proxyMap.get(initialConnectionId);
       containerHelper.disableConnectivity(instanceProxy);
-      containerHelper.disableConnectivity(proxyReadOnlyCluster);
 
       assertFirstQueryThrows(conn, "08S02");
 
       final String newConnectionId = queryInstanceId(conn);
-      assertTrue(isDBInstanceReader(newConnectionId));
+      assertTrue(conn.isReadOnly());
       assertNotEquals(newConnectionId, initialConnectionId);
     }
   }

--- a/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
+++ b/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
@@ -29,6 +29,7 @@ package testsuite.integration.container;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.jdbc.ha.plugins.failover.IClusterAwareMetricsReporter;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -578,6 +579,7 @@ public class AuroraMysqlIntegrationTest extends AuroraMysqlIntegrationBaseTest {
   }
 
   /** Connect to a readonly cluster endpoint and ensure that we are doing a reader failover. */
+  @Disabled // Fails often due to connecting to a writer instance
   @Test
   public void test_ClusterEndpointReadOnlyFailover() throws SQLException, IOException {
     try (final Connection conn = connectToInstance(MYSQL_RO_CLUSTER_URL + PROXIED_DOMAIN_NAME_SUFFIX, MYSQL_PROXY_PORT)) {

--- a/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
+++ b/src/test/java/testsuite/integration/container/AuroraMysqlIntegrationTest.java
@@ -578,23 +578,4 @@ public class AuroraMysqlIntegrationTest extends AuroraMysqlIntegrationBaseTest {
     }
   }
 
-  /** Connect to a readonly cluster endpoint and ensure that read-only property is carried over failover. */
-  @Test
-  public void test_ClusterEndpointReadOnlyFailover() throws SQLException, IOException {
-    try (final Connection conn = connectToInstance(MYSQL_RO_CLUSTER_URL + PROXIED_DOMAIN_NAME_SUFFIX, MYSQL_PROXY_PORT)) {
-      assertTrue(conn.isReadOnly());
-
-      final String initialConnectionId = queryInstanceId(conn);
-
-      final Proxy instanceProxy = proxyMap.get(initialConnectionId);
-      containerHelper.disableConnectivity(instanceProxy);
-
-      assertFirstQueryThrows(conn, "08S02");
-
-      final String newConnectionId = queryInstanceId(conn);
-      assertTrue(conn.isReadOnly());
-      assertNotEquals(newConnectionId, initialConnectionId);
-    }
-  }
-
 }

--- a/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
+++ b/src/test/java/testsuite/integration/utility/AuroraTestUtility.java
@@ -196,7 +196,8 @@ public class AuroraTestUtility {
             .withDBClusterIdentifier(dbIdentifier)
             .withDBInstanceClass(dbInstanceClass)
             .withEngine(dbEngine)
-            .withPubliclyAccessible(true);
+            .withPubliclyAccessible(true)
+            .withTags(testRunnerTag);
 
         for (int i = 1; i <= numOfInstances; i++) {
             rdsClient.createDBInstance(dbInstanceRequest.withDBInstanceIdentifier(dbIdentifier + "-" + i));


### PR DESCRIPTION
### Summary

Allow Forked PR to run CI

### Description

Allow forked PRs to use secrets through environment. CI from PRs will now need to be approved before running.
Disabled `test_ClusterEndpointReadOnlyFailover`. Often fails due to connecting to a writer instance when using Read-only cluster URL.