### PR TITLE
chore: Remove Integration Tests from PR Triggers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,64 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  approve:
-    name: 'Require Approval'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Approve
-        run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
-  ubuntu-latest-aurora-run-integration-tests:
-    needs: [approve]
-    concurrency: IntegrationTests
-    environment: 'Integration Forked Pull Request'
-    name: 'Run Integration Tests'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Clone Repository'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 50
-      - name: 'Set up JDK 8'
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: 'Set up Temp AWS Credentials'
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
-      - name: 'Run Integration Tests'
-        run: |
-          ./gradlew --no-parallel --no-daemon test-integration-docker
-        env:
-          TEST_DB_CLUSTER_IDENTIFIER: ${{ secrets.TEST_DB_CLUSTER_IDENTIFIER }}-${{ github.run_id }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-      - name: 'Archive junit results'
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: 'junit-report'
-          path: build/reports/tests/
-          retention-days: 5
-
   ubuntu-latest-aurora-run-community-tests:
     name: 'Run Community Tests'
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Remove Integration Tests from PR Triggers

### Description

Removes integration tests from PRs as there is no safe way to access secrets which would be used to authenticate the runner.